### PR TITLE
[ci] Save log files from output run

### DIFF
--- a/internal/test/wmcb/main_test.go
+++ b/internal/test/wmcb/main_test.go
@@ -31,6 +31,8 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 	testStatus := m.Run()
+	// Retrieve artifacts after running the test
+	framework.RetrieveArtifacts()
 	// TODO: Add one more check to remove lingering cloud resources
 	framework.TearDown()
 	os.Exit(testStatus)

--- a/internal/test/wsu/main_test.go
+++ b/internal/test/wsu/main_test.go
@@ -30,6 +30,8 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 	testStatus := m.Run()
+	// Retrieve artifacts after running the test
+	framework.RetrieveArtifacts()
 	// TODO: Add one more check to remove lingering cloud resources
 	framework.TearDown()
 	os.Exit(testStatus)


### PR DESCRIPTION
As of now, we are not retrieving the log files for
kubelet and wsu after wsu, wmcb are run. This commit
should address the issue.

- Added a basic implementation of retrieve files in Windows VM
- Updated TestMain to call retrieve files in WSU, WMCB
- Add functionality to collect wsu output

As of now, we're not collecting log files
related to wsu runs. This commit should
address this issue.

Co-authored-by: Sebastian Soto <ssoto@redhat.com>