### PR TITLE
[ci] Revert OVN workaround

### DIFF
--- a/hack/run-wsu-ci-e2e-test.sh
+++ b/hack/run-wsu-ci-e2e-test.sh
@@ -47,6 +47,6 @@ oc patch network.operator cluster --type=merge -p '{"spec":{"defaultNetwork":{"o
 
 # Run the test suite
 cd $TEST_DIR
-GO_BUILD_ARGS=CGO_ENABLED=0 GO111MODULE=on CLUSTER_ADDR=$CLUSTER_ADDR WSU_PATH=$WMCO_ROOT/tools/ansible/tasks/wsu/main.yaml go test -v -vmCreds="$VM_CREDS" $SKIP_VM_SETUP -timeout 90m .
+GO_BUILD_ARGS=CGO_ENABLED=0 GO111MODULE=on CLUSTER_ADDR=$CLUSTER_ADDR WSU_PATH=$WMCO_ROOT/tools/ansible/tasks/wsu/main.yaml go test -v -vmCreds="$VM_CREDS" $SKIP_VM_SETUP -timeout 60m .
 
 exit 0

--- a/internal/test/wsu/wsu_test.go
+++ b/internal/test/wsu/wsu_test.go
@@ -355,9 +355,6 @@ func testEastWestNetworking(t *testing.T, node *v1.Node, vm e2ef.WindowsVM) {
 
 	// test Windows <-> Linux
 	// This will install curl and then curl the windows server.
-	// TODO: This delay was added to work around a bug in OVN
-	//       Remove this sleep once https://bugzilla.redhat.com/show_bug.cgi?id=1789881 is fixed
-	time.Sleep(time.Minute * 10)
 	linuxCurlerCommand := []string{"bash", "-c", "yum update; yum install curl -y; curl " + winServerIP}
 	linuxCurlerJob, err := createLinuxJob("linux-curler-"+vm.GetCredentials().GetInstanceId(), linuxCurlerCommand)
 	require.NoError(t, err, "Could not create Linux job")


### PR DESCRIPTION
This reverts commit 6467b06598ee868d6508c41dc90e859e6761bef4. This
commit will be able to be merged once
https://bugzilla.redhat.com/show_bug.cgi?id=1789881 has been fixed.

This revert is being done since the commit was made only to workaround
the above mentioned bug.