### PR TITLE
[wsu] Autodownload binaries based on cluster version

### DIFF
--- a/internal/test/framework/windowsvm.go
+++ b/internal/test/framework/windowsvm.go
@@ -39,6 +39,9 @@ type windowsVM struct {
 	sshClient *ssh.Client
 	// winrmClient to access the Windows VM created
 	winrmClient *winrm.Client
+	// buildWMCB indicates if WSU should build WMCB and use it
+	// TODO This is a WSU specific property and should be moved to wsu_test -> https://issues.redhat.com/browse/WINC-249
+	buildWMCB bool
 }
 
 // WindowsVM is the interface for interacting with a Windows VM in the test framework
@@ -64,6 +67,11 @@ type WindowsVM interface {
 	Reinitialize() error
 	// Destroy destroys the Windows VM
 	Destroy() error
+	// BuildWMCB returns the value of buildWMCB. It can be used by WSU to decide if it should build WMCB before using it
+	BuildWMCB() bool
+	// SetBuildWMCB sets the value of buildWMCB. Setting buildWMCB to true would indicate WSU will build WMCB instead of
+	// downloading the latest as per the cluster version. False by default
+	SetBuildWMCB(bool)
 }
 
 // newWindowsVM creates and sets up a Windows VM in the cloud and returns the WindowsVM interface that can be used to
@@ -356,4 +364,12 @@ func (w *windowsVM) getSSHClient() error {
 	}
 	w.sshClient = sshClient
 	return nil
+}
+
+func (w *windowsVM) BuildWMCB() bool {
+	return w.buildWMCB
+}
+
+func (w *windowsVM) SetBuildWMCB(buildWMCB bool) {
+	w.buildWMCB = buildWMCB
 }

--- a/internal/test/wsu/main_test.go
+++ b/internal/test/wsu/main_test.go
@@ -8,11 +8,13 @@ import (
 	"testing"
 )
 
-// framework holds the instantiation of test suite being executed. As of now, temp dir is hardcoded.
 var (
-	framework = &e2ef.TestFramework{}
+	// Initialize wsuFramework which specializes TestFramework by adding some properties specific to WSU tests
+	framework = wsuFramework{}
 	// TODO: expose this to the end user as a command line flag
 	// vmCount is the number of VMs the test suite requires
+	// Bring up 2 vms to test wsu run with automatic download of WMCB based on cluster version as well as built from
+	// source version
 	vmCount = 2
 )
 

--- a/tools/ansible/README.md
+++ b/tools/ansible/README.md
@@ -48,7 +48,12 @@ Run the WSU playbook:
 ```
 $ ansible-playbook -i hosts tasks/wsu/main.yaml -v
 ```
+On a default run, WSU will automatically get the latest version of WMCB based on the cluster version.
 
+To use WSU which builds WMCB for development purposes, set value of `build_wmcb` to `True`:
+```
+$ ansible-playbook -i hosts tasks/wsu/main.yaml -v -e "{build_wmcb: True}"
+```
 ### End to end testing
 The following environment variables need to be set for running the end to end tests of the playbook:
 - ARTIFACT_DIR

--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -2,8 +2,8 @@
 - hosts: localhost
   vars:
     project_root: "{{ playbook_dir }}/../../../.."
-    kubelet_location: "https://dl.k8s.io/v1.16.2/kubernetes-node-windows-amd64.tar.gz"
     wmcb_exe: "wmcb.exe"
+    hybrid_overlay_exe : "hybrid-overlay.exe"
 
   tasks:
     - name: Check if cluster is using ovn-kubernetes
@@ -20,6 +20,79 @@
         msg: "Cluster not patched for hybrid overlay"
       when: "hybrid_query.stdout == ''"
 
+    # Expected value of kubernetes_version in the form of 'v1.17.2'
+    - name: Get kubernetes version
+      shell: "oc version -o json | jq -r '.serverVersion.gitVersion'"
+      register: kubernetes_version
+      failed_when: kubernetes_version.stdout == ""
+
+    # kubernetes_version v1.17.2 should correspond to 1.17 for getting changelog url
+    - name: Get kubernetes version without patch version
+      shell: "version={{ kubernetes_version.stdout }} ; echo ${version%.*} | tr -d v"
+      register: kubernetes_version_without_patch
+      failed_when: kubernetes_version_without_patch.stdout == ""
+
+    # Changelog url to lookup SHA for kube node binaries
+    # Example: https://github.com/kubernetes/kubernetes/blob/release-1.17/CHANGELOG/CHANGELOG-1.17.md
+    - name: Get kubernetes changelog url
+      shell: |
+        echo "https://github.com/kubernetes/kubernetes/blob/release-"\
+        "{{ kubernetes_version_without_patch.stdout }}/CHANGELOG/CHANGELOG-"\
+        "{{ kubernetes_version_without_patch.stdout }}.md"
+      register: changelog
+
+    # Get SHA512 for kubernetes-node-windows-amd64 binary released for the kubernetes patch version of the cluster
+    - name: Get kube node binary SHA
+      shell: |
+        curl -s "{{ changelog.stdout }}" | \
+        grep -A 1 "{{ kubernetes_version.stdout }}" | \
+        grep -A 1 node-windows | tail -n 1 | sed -e 's/.*<code>\(.*\)<\/code>.*/\1/'
+      register: kube_node_sha
+      failed_when: kube_node_sha.stdout == ""
+
+    - name: Set kubelet location
+      set_fact:
+        # Example of kubelet download url: "https://dl.k8s.io/v1.16.2/kubernetes-node-windows-amd64.tar.gz"
+        kubelet_location: "https://dl.k8s.io/{{ kubernetes_version.stdout }}/kubernetes-node-windows-amd64.tar.gz"
+
+    - name: Get kubernetes minor version
+      shell: "echo {{ kubernetes_version_without_patch.stdout }} | cut -d '.' -f2"
+      register: kubernetes_minor_version
+      failed_when: kubernetes_minor_version.stdout == ""
+
+    # This translates a kubernetes minor version to an OpenShift version. This works under the assumption that each
+    # OpenShift release corresponds with a kubernetes release. This is being done this way, and not with oc get
+    # clusterversion, as OpenShift CI doesn't have the actual version attached to its clusters, instead replacing it
+    # with 0.0.1 and information about the release creation date
+    # TODO Track the validity of this script when OpenShift version is bumped and the corresponding Kubernetes version is not
+    - name: Get cluster version
+      shell: |
+        MINORVERSION={{ kubernetes_minor_version.stdout }}
+        BASEK8SVERSION=16
+        BASEOPENSHIFTVERSION=3
+        if [ \"$MINORVERSION\" -lt \"$BASEK8SVERSION\" ]; then
+        echo unsupported kubernetes version; exit 1
+        fi
+        VERSIONINCREMENTS=$((MINORVERSION - BASEK8SVERSION))
+        echo 4.$((BASEOPENSHIFTVERSION + VERSIONINCREMENTS))
+        exit 0
+      register: cluster_version
+      failed_when: cluster_version.stdout == ""
+
+    # curl -s https://api.github.com/repos/openshift/windows-machine-config-bootstrapper/releases gets the list of all
+    # releases, we use the cluster version from previous ansible task to select the release we need.
+    # TODO Ensure latest release is available for every new OpenShift version
+    - name: Get release
+      shell: |
+        RELEASES="$(curl -s https://api.github.com/repos/openshift/windows-machine-config-bootstrapper/releases)"
+        TAGNAME="$(echo $RELEASES | jq '.[]' | jq '.tag_name' | \
+        grep -i {{ cluster_version.stdout }} |\
+        sort -r | awk 'NR==1')"
+        echo $RELEASES | \
+        jq '.[] | select (.tag_name == '$TAGNAME')'
+      register: release
+      failed_when: release is not defined or release.stdout == ""
+
     - name: Gather required files
       block:
         - name: Create directory to store files to be used later
@@ -27,18 +100,81 @@
             state: directory
           register: tmp_dir
 
+        # Executed only if 'build_wmcb' is set to True. Default option is downloading the latest release of WMCB
+        # depending on the cluster version
         - name: Build WMCB
-          make:
-            target: build
-            chdir: "{{ project_root }}"
+          # 'build_wmcb' is used as a boolean - it has to be provided in JSON format
+          # https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#passing-variables-on-the-command-line
+          when: build_wmcb is defined and build_wmcb
+          block:
+          - name: Build WMCB
+            make:
+              target: build
+              chdir: "{{ project_root }}"
 
-        - name: Copy WMCB to temporary directory
-          command: cp "{{ project_root }}/{{ wmcb_exe }}" "{{ tmp_dir.path }}/{{ wmcb_exe }}"
+          - name: Copy WMCB to temporary directory
+            command: cp "{{ project_root }}/{{ wmcb_exe }}" "{{ tmp_dir.path }}/{{ wmcb_exe }}"
 
+        - name: Download WMCB binary
+          when: not build_wmcb or build_wmcb is not defined
+          block:
+            # The wmcb release tags are supposed to conform to the following semver format:
+            # v<openshift-major-version>.<openshift-minor-version>.<wmcb_build_number>-<release_type>. For example, v4.4-1-alpha.
+            # For a <openshift-major-version>.<openshift-minor-version>, there can be many wmcb builds available, for
+            # example, OpenShift 4.4 can map to v4.4.1-alpha and v4.4.2-alpha, we will always pick up the latest build available
+            # which is v4.4.2-alpha,
+            # In future, when we cut beta and GA releases, the playbook should always go for GA version when available.
+            - name: Get wmcb url
+              shell: |
+                echo '{{ release.stdout }}' | \
+                jq ' .assets[] | select (.name == "{{ wmcb_exe }}" )' | \
+                jq -r .browser_download_url
+              register: wmcb_download_url
+              failed_when: wmcb_download_url.stdout == ""
+
+            # We'll get the SHA associated with the wmcb.exe in the body of the release tag.
+            - name: Get the SHA for wmcb binary. We assume that body of WMCB release has the info.
+              shell: |
+                echo '{{ release.stdout }}' | \
+                jq -r .body | \
+                grep -i {{ wmcb_exe }}| \
+                awk '{print $1}'
+              register: wmcb_sha
+              failed_when: wmcb_sha.stdout == ""
+
+            # Only download if SHA matches wmcb_sha or fail.
+            - name: Download WMCB
+              get_url:
+                url: "{{ wmcb_download_url.stdout }}"
+                dest: "{{ tmp_dir.path }}/wmcb.exe"
+                checksum: "sha256:{{ wmcb_sha.stdout }}"
+
+        # Get url to download latest hybrid-overlay for the OpenShift cluster version
+        - name: Get hybrid overlay url
+          shell: |
+            echo '{{ release.stdout }}' | \
+            jq ' .assets[] | select (.name == "{{ hybrid_overlay_exe }}" )' | \
+            jq -r .browser_download_url
+          register: hybrid_overlay_download_url
+          failed_when: hybrid_overlay_download_url.stdout == ""
+
+        # We'll get the SHA associated with the hybrid_overlay.exe in the body of the release tag.
+        - name: Get the SHA for hybrid-overlay binary. We assume that body of WMCB release has the info.
+          shell: |
+            echo '{{ release.stdout }}' | \
+            jq -r .body | \
+            grep -i {{ hybrid_overlay_exe }}| \
+            awk '{print $1}'
+          register: hybrid_overlay_sha
+          failed_when: hybrid_overlay_sha.stdout == ""
+
+        # Providing the checksum will ensure the download fails if the binary pointed at by 'kubelet_location' does not
+        # match the SHA512 value associated with kube node binary provided upstream
         - name: Download Windows node kubelet
           get_url:
             url: "{{ kubelet_location }}"
             dest: "{{ tmp_dir.path }}/kube.tar.gz"
+            checksum: "sha512:{{ kube_node_sha.stdout }}"
 
         - name: Extract kubernetes node binaries
           unarchive:
@@ -69,8 +205,7 @@
 - hosts: win
   vars:
     tmp_path: "{{ playbook_dir }}/tmp"
-    hybrid_overlay_exe : "hybrid-overlay.exe"
-    ovn_annotation: "{{ 'hostsubnet' if  ( cluster_version.stdout  == '4.3' ) else  'node-subnet' }}"
+    ovn_annotation: "{{ 'hostsubnet' if  ( hostvars['localhost']['cluster_version']['stdout']  == '4.3' ) else  'node-subnet' }}"
 
   tasks:
     - name: Create temporary directory
@@ -82,6 +217,7 @@
       debug:
         msg: "Windows temporary directory: {{ win_temp_dir.path }}"
 
+    # Uses winRM to transfer files over. win_copy module performs a checksum check on the transferred files by default.
     - name: Copy required files to Windows host
       win_copy:
         src: "{{ hostvars['localhost']['tmp_dir']['path'] }}/"
@@ -93,75 +229,17 @@
         dest: "{{ win_temp_dir.path }}\\worker.ign"
         validate_certs: no
 
-    - name: Get kubernetes version
-      delegate_to: localhost
-      shell: "oc version -o json | jq -r '.serverVersion.minor' | tr -d +"
-      register: kubernetes_version
-
-    # This translates a kubernetes version to an OpenShift version. This works under the assumption that each OpenShift
-    # release corresponds with a kubernetes release. This is being done this way, and not with oc get clusterversion,
-    # as OpenShift CI doesn't have the actual version attached to its clusters, instead replacing it with 0.0.1 and
-    # information about the release creation date
-    - name: Get cluster version
-      delegate_to: localhost
-      shell: |
-        MINORVERSION={{ kubernetes_version.stdout }}
-        BASEK8SVERSION=16
-        BASEOPENSHIFTVERSION=3
-        if [ \"$MINORVERSION\" -lt \"$BASEK8SVERSION\" ]; then
-        echo unsupported kubernetes version; exit 1
-        fi
-        VERSIONINCREMENTS=$((MINORVERSION - BASEK8SVERSION))
-        echo 4.$((BASEOPENSHIFTVERSION + VERSIONINCREMENTS))
-        exit 0
-      register: cluster_version
-
-    # curl -s https://api.github.com/repos/openshift/windows-machine-config-bootstrapper/releases gets the list of all
-    # releases, we use the cluster version from previous ansible task to select the release we need.
-    - name: Get release
-      delegate_to: localhost
-      shell: |
-        RELEASES="$(curl -s https://api.github.com/repos/openshift/windows-machine-config-bootstrapper/releases)"
-        TAGNAME="$(echo $RELEASES | jq '.[]' | jq '.tag_name' | grep -i {{ cluster_version.stdout }} | sort -r | awk 'NR==1')"
-        echo $RELEASES | \
-        jq '.[] | select (.tag_name == '$TAGNAME')'
-      register: release
-
-    # The wmcb release tags are supposed to conform to the following semver format:
-    # v<openshift-major-version>.<openshift-minor-version>.<wmcb_build_number>-<release_type>. For example, v4.4-1-alpha.
-    # For a <openshift-major-version>.<openshift-minor-version>, there can be many wmcb builds available, for
-    # example, OpenShift 4.4 can map to v4.4.1-alpha and v4.4.2-alpha, we will always pick up the latest build available
-    # which is v4.4.2-alpha,
-    # In future, when we cut beta and GA releases, the playbook should always go for GA version when available.
-    - name: Get hybrid overlay url
-      delegate_to: localhost
-      shell: |
-        echo '{{ release.stdout }}' | \
-        jq ' .assets[] | select (.name == "{{ hybrid_overlay_exe }}" )' | \
-        jq -r .browser_download_url
-      register: hybrid_overlay_download_url
-
     - name: Get hybrid overlay exe
       win_get_url:
-        url: "{{ hybrid_overlay_download_url.stdout }}"
+        url: "{{ hostvars['localhost']['hybrid_overlay_download_url']['stdout'] }}"
         dest: "{{ win_temp_dir.path }}\\hybrid-overlay.exe"
         follow_redirects: all
-
-    # We'll get the SHA associated with the hybrid_overlay.exe in the body of the release tag.
-    - name: Get the SHA for the given binary. We assume that body of WMCB release has the info.
-      delegate_to: localhost
-      shell: |
-        echo '{{ release.stdout }}' | \
-        jq -r .body | \
-        grep -i {{ hybrid_overlay_exe }}| \
-        awk '{print $1}'
-      register: hybrid_overlay_sha
 
     # TODO: Remove this, win_get_url already has checksum, we can use it.
     - name: Check hybrid overlay SHA256
       win_shell: "certutil -hashfile {{ win_temp_dir.path }}\\hybrid-overlay.exe sha256"
       register: hybrid_sha256
-      failed_when: "hybrid_sha256.stdout_lines[1] != hybrid_overlay_sha.stdout "
+      failed_when: "hybrid_sha256.stdout_lines[1] != hostvars['localhost']['hybrid_overlay_sha']['stdout']"
 
     - name: Run bootstrapper
       win_shell: "{{ win_temp_dir.path }}\\wmcb.exe initialize-kubelet --ignition-file {{ win_temp_dir.path }}\\worker.ign --kubelet-path {{ win_temp_dir.path }}\\kubelet.exe"


### PR DESCRIPTION
This PR enables WSU to download the latest WMCB, hybrid-overlay and kube node binaries based on the cluster version

To achieve this, first commit introduces TestWindowsVM interface that composes WindowsVM interface. The second commit then introduces a property to TestWindowsVM interface that is used for e2e-wsu tests

Since CI cluster does not give `oc version` in the format of 4.x, kubernetes (server) version is used to map to the corresponding OpenShift version
WSU can now choose to build wmcb or download it based on a boolean argument
E2E SHA check now happens for wmcb (downloaded), hybrid-overlay and kube node binaries, as a part of the playbook

- e2e-wsu tests changed to bring up 2 VMs
- Add property `buildWMCB` to Windows VM interface
- Specialize framework setup for wsu_test.go
- Add extra guards in the playbook to fail early
 
[WINC-131](https://issues.redhat.com/browse/WINC-131)