### PR TITLE
[ci] Use latest WNI

### DIFF
--- a/internal/test/go.mod
+++ b/internal/test/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/masterzen/winrm v0.0.0-20190308153735-1d17eaf15943
 	github.com/openshift/client-go v0.0.0-00010101000000-000000000000
-	github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200214230955-da4e7140409c
+	github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200219203823-675f779e3e8e
 	github.com/pkg/sftp v1.10.1
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c

--- a/internal/test/go.sum
+++ b/internal/test/go.sum
@@ -118,8 +118,8 @@ github.com/openshift/api v0.0.0-20200205145930-e9d93e317dd1 h1:9+nvzkAohurf7NS8m
 github.com/openshift/api v0.0.0-20200205145930-e9d93e317dd1/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20191125132246-f6563a70e19a h1:Otk3CuCAEHiMUr4Er6b+csq4Ar6qilAs9h93tbea+qM=
 github.com/openshift/client-go v0.0.0-20191125132246-f6563a70e19a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
-github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200214230955-da4e7140409c h1:PV10Rzss3fyw6Af/xuqA5AXDW702DRih4Xa6lggLVnE=
-github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200214230955-da4e7140409c/go.mod h1:AP0a6I2jpW0ELubm7J4tVQYAPSBeZhkZzZxInocxs6E=
+github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200219203823-675f779e3e8e h1:T5Q+FCzv4I6YLiQ401abRXSD8o3F8JpyJuavyPGmRQE=
+github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200219203823-675f779e3e8e/go.mod h1:AP0a6I2jpW0ELubm7J4tVQYAPSBeZhkZzZxInocxs6E=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
This commit makes the test framework use the latest WNI, to pick up the
changes made to not log instance secrets. This commit was done by
deleting the WNI line from go.mod, and then running `go mod tidy`.