### PR TITLE
Bug 1805513: Resolve parallel execution of playbook

### DIFF
--- a/internal/test/wsu/main_test.go
+++ b/internal/test/wsu/main_test.go
@@ -13,7 +13,7 @@ var (
 	framework = &e2ef.TestFramework{}
 	// TODO: expose this to the end user as a command line flag
 	// vmCount is the number of VMs the test suite requires
-	vmCount = 1
+	vmCount = 2
 )
 
 func TestMain(m *testing.M) {

--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -32,8 +32,8 @@
             target: build
             chdir: "{{ project_root }}"
 
-        - name: Move WMCB to temporary directory
-          command: mv "{{ project_root }}/{{ wmcb_exe }}" "{{ tmp_dir.path }}/{{ wmcb_exe }}"
+        - name: Copy WMCB to temporary directory
+          command: cp "{{ project_root }}/{{ wmcb_exe }}" "{{ tmp_dir.path }}/{{ wmcb_exe }}"
 
         - name: Download Windows node kubelet
           get_url:


### PR DESCRIPTION
Problem: When we run wsu playbook parrallely for 2 windows vms, the ansible task
'Move wmcb to temporary directory' fails for the second vm. This is because
currently we are building wmcb.exe in the project root directory in both the runs.
So when the run for the first vm has moved the built wmcb.exe to a temporary
directory, run for the second vm cannot find it.

Solution: Instead of moving built wmcb.exe to a temporary directory, we are
copying it