### PR TITLE
[wni] Add a DestroyWindowsVM method to cloud provider interface

### DIFF
--- a/tools/windows-node-installer/pkg/cloudprovider/aws/ec2.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/aws/ec2.go
@@ -275,6 +275,20 @@ func (a *AwsProvider) getDecodedPassword(instanceID string) ([]byte, error) {
 
 }
 
+// DestroyWindowsVM destroys the given Windows VM
+func (a *AwsProvider) DestroyWindowsVM(instanceID string) error {
+	if err := a.TerminateInstance(instanceID); err != nil {
+		return fmt.Errorf("failed deleting the instance %s: %v", instanceID, err)
+	}
+	if err := a.waitUntilInstanceTerminated(instanceID); err != nil {
+		// As of now, I want the error thrown to be consistent across all cloud providers, so I am not specializing
+		// the information in the error message string but the err will have more context. This is cause our operator
+		// to block for a while
+		return fmt.Errorf("failed deleting the instance %s: %v", instanceID, err)
+	}
+	return nil
+}
+
 // waitUntilPasswordDataIsAvailable waits till the ec2 password data is available.
 // AWS sdk's WaitUntilPasswordDataAvailable is returning inspite of password data being available.
 // So, building this function as a wrapper around AWS sdk's GetPasswordData method with constant back-off

--- a/tools/windows-node-installer/pkg/cloudprovider/factory.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/factory.go
@@ -29,6 +29,10 @@ type Cloud interface {
 	// It deletes the security group only if the group is not associated with any instance.
 	// The association between the instance and security group are available from individual cloud provider.
 	DestroyWindowsVMs() error
+	// DestroyWindowsVM destroys a specific instance that was passed to it. It returns an error when the WindowsVM
+	// deletion fails. It takes the instanceID as argument depending on the cloud provider implementation the
+	// instanceID. Let's if we want to slice of instances instead of individual instances
+	DestroyWindowsVM(string) error
 }
 
 // CloudProviderFactory returns cloud specific interface for performing necessary functions related to creating or


### PR DESCRIPTION
As of now, we're deleting the entire Windows VMs created via WNI using
windows-node-installer.json. We'd want a way to just delete a single
Windows VM created via WNI so that we can use it in WMCO. This commit expands
the interface to have that method.

/cc @aravindhp @openshift/openshift-team-windows-containers 