### PR TITLE
[wsu] [CI] Capture hybrid-overlay and kube-proxy output in artifacts_dir

### DIFF
--- a/internal/test/framework/framework.go
+++ b/internal/test/framework/framework.go
@@ -375,10 +375,11 @@ func (f *TestFramework) RetrieveArtifacts() {
 		if err := vm.Reinitialize(); err != nil {
 			log.Printf("failed re-initializing ssh connectivity with on vm %s: %v", instanceID, err)
 		}
-		// Get the VM's private ip and populate log files in the test container.
-		// Make this a map["'"artifact_that_we_want_to_pull"]="log_file.name"
-		if err := vm.RetrieveFiles(remoteLogPath, localKubeletLogPath); err != nil {
-			log.Printf("failed retrieving log files on vm %s: %v", instanceID, err)
+		// TODO: Make this a map["'"artifact_that_we_want_to_pull"]="log_file.name" to only capture
+		//  the logs we are interested in, to avoid capturing every directory in c:\\k\\log
+		// Retrieve directories copies the directories from remote VM to the Artifacts directory
+		if err := vm.RetrieveDirectories(remoteLogPath, localKubeletLogPath); err != nil {
+			log.Printf("failed retrieving log directories on vm %s: %v", instanceID, err)
 			continue
 		}
 	}

--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -206,6 +206,7 @@
   vars:
     tmp_path: "{{ playbook_dir }}/tmp"
     ovn_annotation: "{{ 'hostsubnet' if  ( hostvars['localhost']['cluster_version']['stdout']  == '4.3' ) else  'node-subnet' }}"
+    log_dir: "c:\\k\\log"
 
   tasks:
     - name: Create temporary directory
@@ -329,8 +330,22 @@
       win_shell: "Stop-Process -Name \"hybrid-overlay\""
       when: 'get_process.stderr == ""'
 
+    # The bootstrapper runs in one of the tasks above and makes C:\\k\\log directory created before hand
+    # Creating a hybrid-overlay log directory to store hybrid-overlay specific logs
+    - name: check if hybrid-overlay directory already exists
+      win_stat:
+        path: "{{ log_dir }}\\hybrid-overlay"
+      register: hybridOverlay_dir
+
+    - name: Create a hybrid-overlay directory to store hybrid-overlay logs
+      win_file:
+        path: "{{ log_dir }}\\hybrid-overlay"
+        state: directory
+      when: hybridOverlay_dir.stat.exists == false
+
+      # All the logs for hybrid-overlay are directed to the error log by default, this may change in future for segregation.
     - name: Start the hybrid overlay
-      win_shell: "Start-Process -NoNewWindow -FilePath \"{{  win_temp_dir.path }}\\hybrid-overlay.exe\" -ArgumentList \"--node  {{ node_name.stdout }} --k8s-kubeconfig c:\\k\\kubeconfig\""
+      win_shell: "Start-Process -NoNewWindow -FilePath \"{{  win_temp_dir.path }}\\hybrid-overlay.exe\" -ArgumentList \"--node  {{ node_name.stdout }} --k8s-kubeconfig c:\\k\\kubeconfig\" -RedirectStandardOutput {{log_dir}}\\hybrid-overlay\\hybridOverlayStdout.log -RedirectStandardError {{log_dir}}\\hybrid-overlay\\hybridOverlayStderr.log"
       async: 60
       poll: 0
       register: async_results
@@ -407,10 +422,23 @@
         name: "kube-proxy"
         state: absent
 
+    # The bootstrapper runs in one of the above tasks and makes C:\\k\\log directory created before hand
+    # Creating a kube-proxy log directory to store kube-proxy specific logs
+    - name: check if kube-proxy directory already exists
+      win_stat:
+        path: "{{ log_dir }}\\kube-proxy"
+      register: kubeProxy_dir
+
+    - name: Create a kube-proxy directory to store kube-proxy logs
+      win_file:
+        path: "{{ log_dir }}\\kube-proxy"
+        state: directory
+      when: kubeProxy_dir.stat.exists == false
+
     - name: Start kube-proxy Windows Service
       win_service:
         name: "kube-proxy"
-        path: "C:\\k\\kube-proxy.exe --windows-service --v=4 --proxy-mode=kernelspace --feature-gates=WinOverlay=true --hostname-override={{ node_name.stdout }} --kubeconfig=c:\\k\\kubeconfig --cluster-cidr={{ ovn_host_subnet.stdout }} --log-dir=c:\\k --logtostderr=false --network-name=OpenShiftNetwork --source-vip={{ source_vip.stdout | trim }} --enable-dsr=false"
+        path: "C:\\k\\kube-proxy.exe --windows-service --v=4 --proxy-mode=kernelspace --feature-gates=WinOverlay=true --hostname-override={{ node_name.stdout }} --kubeconfig=c:\\k\\kubeconfig --cluster-cidr={{ ovn_host_subnet.stdout }} --log-dir={{log_dir}}\\kube-proxy\\ --logtostderr=false --network-name=OpenShiftNetwork --source-vip={{ source_vip.stdout | trim }} --enable-dsr=false"
         state: started
         start_mode: auto
         display_name: "kube-proxy"


### PR DESCRIPTION
This PR captures the kube-proxy logs in C:\k\log\kubeProxy\ and the hybrid-overlay logs in C:\k\log\hybridOverlay\ in the remote VM logs directory .

Kube proxy logs are already being captured so they will just be redirected to this new directory and hybrid overlay logs are captured using RedirectStandardError and RedirectStandardOutput arguments in the WSU playbook while the binaries are running. 

This PR also consists addition of  a method RetrieveDirectories to the WindowsVM interface, this was required as the remote log directory on the VM can now consist of a nested directory structure which should be copied to the artifacts directory. 

The E2E test  make sure that the log directories and files are being captured in C:\K\log on the VM.

[[WINC-155]](https://issues.redhat.com/browse/WINC-155)