### PR TITLE
[wsu] Download latest 0.8.x version of CNI plugins

### DIFF
--- a/internal/test/framework/framework.go
+++ b/internal/test/framework/framework.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -69,7 +70,7 @@ type TestFramework struct {
 	ClusterVersion string
 	// latestRelease is the latest release of the wmcb
 	latestRelease *github.RepositoryRelease
-	// latestCniPluginsVersion is the latest 0.8.x version of CNI Plugins
+	// LatestCniPluginsVersion is the latest 0.8.x version of CNI Plugins
 	LatestCniPluginsVersion string
 }
 
@@ -173,8 +174,11 @@ func (f *TestFramework) Setup(vmCount int, credentials []*types.Credentials, ski
 	if err := f.getClusterVersion(); err != nil {
 		return fmt.Errorf("unable to get OpenShift cluster version: %v", err)
 	}
-	if err := f.getLatestGithubRelease(); err != nil {
-		return fmt.Errorf("unable to get latest github release: %v", err)
+	if err := f.getLatestWMCBRelease(); err != nil {
+		return fmt.Errorf("unable to get latest WMCB release: %v", err)
+	}
+	if err := f.getLatestCniPluginsVersion(); err != nil {
+		return fmt.Errorf("unable to get latest 0.8.x version of CNI Plugins: %v", err)
 	}
 	return nil
 }
@@ -238,8 +242,31 @@ func (f *TestFramework) getClusterVersion() error {
 	return nil
 }
 
-// GetGithubReleases gets all the github releases for a given owner and repo
-func (f *TestFramework) GetGithubReleases(owner string, repo string) ([]*github.RepositoryRelease, error) {
+// getLatestCniPluginsVersion returns the latest 0.8.x version of CNI plugins in 'v<major>.<minor>.<patch>' format
+func (f *TestFramework) getLatestCniPluginsVersion() error {
+	releases, err := f.getGithubReleases("containernetworking", "plugins")
+	if err != nil {
+		return err
+	}
+	// Iterating over releases to fetch versions from tag names
+	var cniPluginsVersions = []string{}
+	for _, release := range releases {
+		cniPluginsVersions = append(cniPluginsVersions, release.GetTagName())
+	}
+	// Sorting versions in reverse order so as to get latest version first
+	sort.Sort(sort.Reverse(sort.StringSlice(cniPluginsVersions)))
+	// Iterating over versions to find first 0.8.x version which is not a release candidate
+	for _, cniPluginsVersion := range cniPluginsVersions {
+		if strings.HasPrefix(cniPluginsVersion, "v0.8.") && !strings.Contains(cniPluginsVersion, "rc") {
+			f.LatestCniPluginsVersion = cniPluginsVersion
+			return nil
+		}
+	}
+	return fmt.Errorf("could not fetch latest 0.8.x version of CNI Plugins")
+}
+
+// getGithubReleases gets all the github releases for a given owner and repo
+func (f *TestFramework) getGithubReleases(owner string, repo string) ([]*github.RepositoryRelease, error) {
 	// Initializing a client for using the Github API
 	client := github.NewClient(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
@@ -249,10 +276,10 @@ func (f *TestFramework) GetGithubReleases(owner string, repo string) ([]*github.
 	return releases, err
 }
 
-// getLatestGithubRelease gets the latest github release for the wmcb repo. This release is specific to the cluster
+// getLatestWMCBRelease gets the latest github release for the wmcb repo. This release is specific to the cluster
 // version
-func (f *TestFramework) getLatestGithubRelease() error {
-	releases, err := f.GetGithubReleases("openshift", "windows-machine-config-bootstrapper")
+func (f *TestFramework) getLatestWMCBRelease() error {
+	releases, err := f.getGithubReleases("openshift", "windows-machine-config-bootstrapper")
 	if err != nil {
 		return err
 	}

--- a/internal/test/framework/framework.go
+++ b/internal/test/framework/framework.go
@@ -1,12 +1,15 @@
 package framework
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -37,6 +40,8 @@ const (
 	// remoteLogPath is the directory where all the log files related to components that we need are generated on the
 	// Windows VM
 	remoteLogPath = "C:\\k\\log\\"
+	// cniPluginsBaseURL is the base URL of the CNI Plugins location
+	cniPluginsBaseURL = "https://github.com/containernetworking/plugins/releases/download/"
 )
 
 var (
@@ -69,6 +74,8 @@ type TestFramework struct {
 	ClusterVersion string
 	// latestRelease is the latest release of the wmcb
 	latestRelease *github.RepositoryRelease
+	// latestCniPluginsVersion is the latest 0.8.x version of CNI Plugins
+	LatestCniPluginsVersion string
 }
 
 // Creds is used for parsing the vmCreds command line argument
@@ -173,6 +180,9 @@ func (f *TestFramework) Setup(vmCount int, credentials []*types.Credentials, ski
 	}
 	if err := f.getLatestGithubRelease(); err != nil {
 		return fmt.Errorf("unable to get latest github release: %v", err)
+	}
+	if err := f.getLatestCniPluginsVersion(); err != nil {
+		return fmt.Errorf("unable to get latest 0.8.x version of CNI Plugins: %v", err)
 	}
 	return nil
 }
@@ -282,6 +292,67 @@ func (f *TestFramework) GetReleaseArtifactSHA(artifactName string) (string, erro
 		}
 	}
 	return "", fmt.Errorf("no artifact with name %s", artifactName)
+}
+
+// getLatestCniPluginsVersion returns the latest 0.8.x version of CNI plugins in 'v<major>.<minor>.<patch>' format
+func (f *TestFramework) getLatestCniPluginsVersion() error {
+	client := github.NewClient(nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	defer cancel()
+	releases, _, err := client.Repositories.ListReleases(ctx, "containernetworking", "plugins",
+		&github.ListOptions{})
+	if err != nil {
+		return err
+	}
+	// Iterating over releases to fetch versions from tag names
+	var cniPluginsVersions = []string{}
+	for _, release := range releases {
+		cniPluginsVersions = append(cniPluginsVersions, release.GetTagName())
+	}
+	// Sorting versions in reverse order so as to get latest version first
+	sort.Sort(sort.Reverse(sort.StringSlice(cniPluginsVersions)))
+	// Iterating over versions to find first 0.8.x version which is not a release candidate
+	for _, cniPluginsVersion := range cniPluginsVersions {
+		if strings.HasPrefix(cniPluginsVersion, "v0.8.") && !strings.Contains(cniPluginsVersion, "rc") {
+			f.LatestCniPluginsVersion = cniPluginsVersion
+			return nil
+		}
+	}
+	return fmt.Errorf("could not fetch latest 0.8.x version of CNI Plugins")
+}
+
+// GetLatestCniPluginsURL returns the URL of the latest 0.8.x version of CNI Plugins
+func (f *TestFramework) GetLatestCniPluginsURL() (string, error) {
+	latestCniPluginsURL := cniPluginsBaseURL + f.LatestCniPluginsVersion + "/cni-plugins-windows-amd64-" +
+		f.LatestCniPluginsVersion + ".tgz"
+	return latestCniPluginsURL, nil
+}
+
+// GetLatestCniPluginsSHA returns the SHA512 of the latest 0.8.x version of CNI Plugins
+func (f *TestFramework) GetLatestCniPluginsSHA() (string, error) {
+	latestCniPluginsURL, err := f.GetLatestCniPluginsURL()
+	if err != nil {
+		return "", fmt.Errorf("could not fetch latest CNI Plugins URL: %s", err)
+	}
+
+	latestCniPluginsChecksumFileURL := latestCniPluginsURL + ".sha512"
+	response, err := http.Get(latestCniPluginsChecksumFileURL)
+	if err != nil {
+		return "", fmt.Errorf("could not fetch CNI Plugins checksum file: %s", err)
+	}
+	defer response.Body.Close()
+
+	var checksumFileContent string
+	// Fetching checksum file content from the GET Response
+	scanner := bufio.NewScanner(response.Body)
+	for scanner.Scan() {
+		checksumFileContent = scanner.Text()
+	}
+	// The checksum file content is in the format "<sha> <filename>". So to get SHA we need to extract only the <sha>
+	// from the file
+	sha512 := strings.Split(checksumFileContent, " ")[0]
+	return sha512, nil
 }
 
 // GetNode returns a pointer to the node object associated with the external IP provided

--- a/internal/test/wmcb/main_test.go
+++ b/internal/test/wmcb/main_test.go
@@ -11,7 +11,8 @@ import (
 
 // framework holds the instantiation of test suite being executed. As of now, temp dir is hardcoded.
 var (
-	framework = &e2ef.TestFramework{}
+	// Initialize wmcbFramework which specializes TestFramework by adding some properties specific to WMCB tests
+	framework = wmcbFramework{}
 	// TODO: expose this to the end user as a command line flag
 	// vmCount is the number of VMs the test suite requires
 	vmCount = 1

--- a/internal/test/wmcb/wmcb_test.go
+++ b/internal/test/wmcb/wmcb_test.go
@@ -66,11 +66,7 @@ var (
 		shaType: "sha512",
 	}
 	// cniPlugins contains information about the CNI plugin package
-	cniPlugins = pkgInfo{
-		url:     "https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-windows-amd64-v0.8.2.tgz",
-		sha:     "705a760673fd9e2164ac38f0df7d739ca6c3ec4f4204b0c439227ec6da7cb153859013c917e7f8f1a9456365dd9193f627a7e9e4e1981725cab89bb5ab881ec0",
-		shaType: "sha512",
-	}
+	cniPlugins = pkgInfo{}
 )
 
 // wmcbVM is a wrapper for the WindowsVM interface that associates it with WMCB specific testing
@@ -88,9 +84,29 @@ type pkgInfo struct {
 	shaType string
 }
 
+func initializeCniPluginsPkgInfo() error {
+	cniPluginsURL, err := framework.GetLatestCniPluginsURL()
+	if err != nil {
+		return fmt.Errorf("unable to get URL for CNI Plugins: %v", err)
+	}
+	cniPlugins.url = cniPluginsURL
+
+	cniPluginsSHA, err := framework.GetLatestCniPluginsSHA()
+	if err != nil {
+		return fmt.Errorf("unable to get SHA for CNI Plugins: %v", err)
+	}
+	cniPlugins.sha = cniPluginsSHA
+
+	cniPlugins.shaType = "sha512"
+	return nil
+}
+
 // TestWMCB runs the unit and e2e tests for WMCB on the remote VMs
 func TestWMCB(t *testing.T) {
 	remoteDir := "C:\\Temp"
+	err := initializeCniPluginsPkgInfo()
+	require.NoError(t, err, "error while initializing CNI Plugins package info")
+
 	for _, vm := range framework.WinVMs {
 		wVM := &wmcbVM{vm}
 		files := strings.Split(*filesToBeTransferred, ",")

--- a/internal/test/wsu/wsu_test.go
+++ b/internal/test/wsu/wsu_test.go
@@ -372,6 +372,8 @@ func testCNIPluginsVersion(t *testing.T, vm e2ef.TestWindowsVM) {
 			cniBinaryDir = kubeletArgOptionAndValue[1]
 		}
 	}
+	// Throwing error if directory of CNI Plugin binaries could not be fetched from kubelet service image path
+	require.NotEmpty(t, cniBinaryDir, "Could not fetch directory path of CNI Plugin binaries")
 	// Fetching names of CNI Plugins as a comma separated string
 	// Example: flannel,host-local,win-bridge,win-overlay
 	pluginNamesCommaSeparated, _, err := vm.Run("(gci -FILE "+cniBinaryDir+").basename -join ','", true)

--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -206,26 +206,13 @@
             src: "{{ tmp_dir.path }}/kubernetes/node/bin/kube-proxy.exe"
             dest: "{{ tmp_dir.path }}/kube-proxy.exe"
 
-        - name: Download checksum file for cni plugins
-          get_url:
-            url: "{{ cni_plugins_location }}.sha512"
-            dest: "{{ tmp_dir.path }}/cni_plugins_checksum_file"
-
-        # The checksum file content is in the format "<sha> <filename>". So to get SHA we need to extract only the <sha>
-        # from the file
-        - name: Get the SHA for cni plugins
-          shell: |
-            cat {{ tmp_dir.path }}/cni_plugins_checksum_file | awk -F ' ' '{print $1}'
-          register: cni_plugins_sha
-          failed_when: cni_plugins_sha.stdout == ""
-
         # We match the SHA512 of the downloaded file with the one that is provided upstream to ensure integrity and
         # verify that the download has completed successfully
         - name: Download cni plugins
           get_url:
             url: "{{ cni_plugins_location }}"
             dest: "{{ tmp_dir.path }}/cni_plugins.tgz"
-            checksum: "sha512:{{ cni_plugins_sha.stdout }}"
+            checksum: "sha512:{{ cni_plugins_location }}.sha512"
 
         - name: Create temporary cni directory
           file:

--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -60,6 +60,21 @@
       register: kubernetes_minor_version
       failed_when: kubernetes_minor_version.stdout == ""
 
+    # curl -s https://api.github.com/containernetworking/plugins/releases gets the list of all releases. We get all the
+    # available versions from the tag_name. Finally, we sort the versions to get latest 0.8.x version which is not a
+    # release candidate
+    - name: Get latest 0.8.x cni plugins version
+      shell: |
+        RELEASES="$(curl -s https://api.github.com/repos/containernetworking/plugins/releases)"
+        echo $RELEASES | jq '.[]' | jq '.tag_name' |
+        sort -r |  awk '/"v0.8.*"/ && !/v0.8.*-rc*/ {print substr($1,2,length($1)-2); exit}'
+      register: cni_plugins_version
+      failed_when: cni_plugins_version is not defined or cni_plugins_version.stdout == ""
+
+    - name: Set cni plugins location
+      set_fact:
+        cni_plugins_location: "https://github.com/containernetworking/plugins/releases/download/{{ cni_plugins_version.stdout }}/cni-plugins-windows-amd64-{{ cni_plugins_version.stdout }}.tgz"
+
     # This translates a kubernetes minor version to an OpenShift version. This works under the assumption that each
     # OpenShift release corresponds with a kubernetes release. This is being done this way, and not with oc get
     # clusterversion, as OpenShift CI doesn't have the actual version attached to its clusters, instead replacing it
@@ -191,16 +206,36 @@
             src: "{{ tmp_dir.path }}/kubernetes/node/bin/kube-proxy.exe"
             dest: "{{ tmp_dir.path }}/kube-proxy.exe"
 
+        - name: Download checksum file for cni plugins
+          get_url:
+            url: "{{ cni_plugins_location }}.sha512"
+            dest: "{{ tmp_dir.path }}/cni_plugins_checksum_file"
+
+        # The checksum file content is in the format "<sha> <filename>". So to get SHA we need to extract only the <sha>
+        # from the file
+        - name: Get the SHA for cni plugins
+          shell: |
+            cat {{ tmp_dir.path }}/cni_plugins_checksum_file | awk -F ' ' '{ print $1 }'
+          register: cni_plugins_sha
+          failed_when: cni_plugins_sha.stdout == ""
+
+        # We match the SHA512 of the downloaded file with the one that is provided upstream to ensure integrity and
+        # verify that the download has completed successfully
+        - name: Download cni plugins
+          get_url:
+            url: "{{ cni_plugins_location }}"
+            dest: "{{ tmp_dir.path }}/cni_plugins.tgz"
+            checksum: "sha512:{{ cni_plugins_sha.stdout }}"
+
         - name: Create temporary cni directory
           file:
             path: "{{ tmp_dir.path }}/cni"
             state: directory
 
-        - name: Get cni plugins
+        - name: Extract cni plugins
           unarchive:
-            src: "https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-windows-amd64-v0.8.2.tgz"
+            src: "{{ tmp_dir.path }}/cni_plugins.tgz"
             dest: "{{ tmp_dir.path }}/cni"
-            remote_src: yes
 
 - hosts: win
   vars:

--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -215,7 +215,7 @@
         # from the file
         - name: Get the SHA for cni plugins
           shell: |
-            cat {{ tmp_dir.path }}/cni_plugins_checksum_file | awk -F ' ' '{ print $1 }'
+            cat {{ tmp_dir.path }}/cni_plugins_checksum_file | awk -F ' ' '{print $1}'
           register: cni_plugins_sha
           failed_when: cni_plugins_sha.stdout == ""
 
@@ -236,6 +236,12 @@
           unarchive:
             src: "{{ tmp_dir.path }}/cni_plugins.tgz"
             dest: "{{ tmp_dir.path }}/cni"
+
+        # Removing cni_plugins.tgz from temporary directory as we do not want to copy it to Windows VM
+        - name: Remove cni plugins tar
+          file:
+            path: "{{ tmp_dir.path }}/cni_plugins.tgz"
+            state: absent
 
 - hosts: win
   vars:


### PR DESCRIPTION
Currently, we are hard coding the CNI plugins version to 0.8.2. This PR makes
wsu playbook dynamically pick the latest 0.8.x version of CNI plugins from repo's
release page.