### PR TITLE
Rename copyFile function

### DIFF
--- a/internal/test/wmcb/wmcb_test.go
+++ b/internal/test/wmcb/wmcb_test.go
@@ -95,7 +95,7 @@ func TestWMCB(t *testing.T) {
 		wVM := &wmcbVM{vm}
 		files := strings.Split(*filesToBeTransferred, ",")
 		for _, file := range files {
-			err := wVM.CopyFile(file, remoteDir)
+			err := wVM.CopyFileTo(file, remoteDir)
 			require.NoError(t, err, "error copying %s to the Windows VM", file)
 		}
 		t.Run("Unit", func(t *testing.T) {
@@ -267,7 +267,7 @@ func (vm *wmcbVM) initializeTestConfigureCNIFiles(ovnHostSubnet string) error {
 	}
 
 	// Copy the created config to C:\Window\Temp\cni\config\cni.conf on the Windows VM
-	err = vm.CopyFile(cniConfigPath, winCNIConfigPath)
+	err = vm.CopyFileTo(cniConfigPath, winCNIConfigPath)
 	if err != nil {
 		return fmt.Errorf("error copying %s --> VM %s: %v", cniConfigPath, winCNIConfigPath, err)
 	}

--- a/tools/windows-node-installer/pkg/types/types.go
+++ b/tools/windows-node-installer/pkg/types/types.go
@@ -46,9 +46,9 @@ type Windows struct {
 
 // WindowsVM is the interface for interacting with a Windows object created by the cloud provider
 type WindowsVM interface {
-	// CopyFile copies the given file to the remote directory in the Windows VM. The remote directory is created if it
+	// CopyFileTo copies the given file to the remote directory in the Windows VM. The remote directory is created if it
 	// does not exist
-	CopyFile(string, string) error
+	CopyFileTo(string, string) error
 	// Run executes the given command remotely on the Windows VM and returns the output of stdout and stderr. If the
 	// bool is set, it implies that the cmd is to be execute in PowerShell.
 	Run(string, bool) (string, string, error)
@@ -64,9 +64,9 @@ type WindowsVM interface {
 	Reinitialize() error
 }
 
-func (w *Windows) CopyFile(filePath, remoteDir string) error {
+func (w *Windows) CopyFileTo(filePath, remoteDir string) error {
 	if w.SSHClient == nil {
-		return fmt.Errorf("CopyFile cannot be called without a SSH client")
+		return fmt.Errorf("CopyFileTo cannot be called without a SSH client")
 	}
 
 	ftp, err := sftp.NewClient(w.SSHClient)


### PR DESCRIPTION
The purpose of this PR is to rename the copyFile function to copyFileTo which copies from local to remote. This change was necessary to make the WindowsVM interface clear for further implementations, with the addition of a new function copyFileFrom in PR #162 that copies file from remote to local.