### PR TITLE
[wni] Enable SSH networking for windows node

### DIFF
--- a/tools/windows-node-installer/pkg/cloudprovider/aws/ec2.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/aws/ec2.go
@@ -38,9 +38,6 @@ const (
 	//  after launching an instance before trying to retrieve the generated password.`
 	// Ref: https://godoc.org/github.com/aws/aws-sdk-go/service/ec2#EC2.GetPasswordData
 	awsPasswordDataTimeOut = 15 * time.Minute
-	// sshPort to access the OpenSSH server installed on the windows node. This is needed
-	// for our CI testing.
-	sshPort = 22
 	//RDP port for requests
 	rdpPort = 3389
 )
@@ -658,8 +655,8 @@ func examineRulesInSg(myIP string, rules []*ec2.IpPermission, vpcCidr string) ([
 	if !portTracker[WINRM_PORT] {
 		ports = append(ports, WINRM_PORT)
 	}
-	if !portTracker[sshPort] {
-		ports = append(ports, sshPort)
+	if !portTracker[types.SshPort] {
+		ports = append(ports, types.SshPort)
 	}
 	if !portTracker[rdpPort] {
 		ports = append(ports, rdpPort)

--- a/tools/windows-node-installer/pkg/types/types.go
+++ b/tools/windows-node-installer/pkg/types/types.go
@@ -28,6 +28,8 @@ const (
 	remotePowerShellCmdPrefix = "powershell.exe -NonInteractive -ExecutionPolicy Bypass "
 	// winRMPort is port used for WinRM communication
 	winRMPort = 5986
+	// SshPort is the SSH port
+	SshPort = 22
 )
 
 // Windows represents a Windows host.

--- a/tools/windows-node-installer/test/e2e/azure_test.go
+++ b/tools/windows-node-installer/test/e2e/azure_test.go
@@ -354,8 +354,16 @@ func testAnsiblePing(t *testing.T) {
 
 // testAzureFirewallRule asserts if the created instance has firewall rule that opens container logs port.
 func testAzureInstancesFirewallRule(t *testing.T) {
+	windowsVM = getAzureWindowsVM(t)
+	testInstanceFirewallRule(t)
+}
+
+// Gets a WindowsVM instance object with credentials
+func getAzureWindowsVM(t *testing.T) (windowsVM types.WindowsVM) {
+	w := &types.Windows{}
 	ipAddress, password, err := getIpPass(credentials.GetInstanceId())
 	require.NoErrorf(t, err, "failed to obtain credentials for %s", credentials.GetInstanceId())
 	credentials = types.NewCredentials(credentials.GetInstanceId(), ipAddress, password, azureUser)
-	testInstanceFirewallRule(t)
+	w.Credentials = credentials
+	return w
 }

--- a/tools/windows-node-installer/test/e2e/common.go
+++ b/tools/windows-node-installer/test/e2e/common.go
@@ -16,6 +16,8 @@ import (
 const (
 	// winRMPort is the secure WinRM port
 	winRMPort = "5986"
+	// sshPort is the SSH port
+	sshPort = "22"
 )
 
 var (


### PR DESCRIPTION
This PR opens up the SSH port for local IP of the user and installs OpenSSH server on the windows node for Azure VMs. This PR includes e2e tests for testing OpenSSH connections on Azure VMs