### PR TITLE
fix windows struct nil pointer

### DIFF
--- a/internal/test/framework/windowsvm.go
+++ b/internal/test/framework/windowsvm.go
@@ -81,6 +81,7 @@ func newWindowsVM(imageID, instanceType string, credentials *types.Credentials, 
 		if credentials.GetIPAddress() == "" || credentials.GetPassword() == "" {
 			return nil, fmt.Errorf("password or IP address not specified in credentials")
 		}
+		w.Windows = &types.Windows{}
 		w.Credentials = credentials
 	}
 


### PR DESCRIPTION
  https://github.com/openshift/windows-machine-config-bootstrapper/pull/157 caused the functionality of testing using existing WindowsVMs broken. This commit should address that. Tested this locally and it works fine.