### PR TITLE
Bug 1809291: [wsu] Ensure kube-proxy service is not running.

### DIFF
--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -430,6 +430,11 @@
         msg: "CNI Configuration error"
       when: '"CNI configuration completed successfully" not in bootstrap_out.stderr'
 
+    - name: Ensure kube-proxy Windows Service is not running
+      win_service:
+        name: "kube-proxy"
+        state: absent
+
     - name: Copy kube-proxy to C:\k
       win_copy:
         src: "{{ win_temp_dir.path }}\\kube-proxy.exe"
@@ -444,11 +449,6 @@
     - name: Get source-vip
       win_shell: 'Import-Module {{ win_temp_dir.path }}\\hns.psm1; $net = (Get-HnsNetwork | where { $_.Name -eq "OpenShiftNetwork" }); $endpoint = New-HnsEndpoint -NetworkId $net.ID -Name VIPEndpoint; Attach-HNSHostEndpoint -EndpointID $endpoint.ID -CompartmentID 1; (Get-NetIPConfiguration -AllCompartments -All -Detailed | where { $_.NetAdapter.LinkLayerAddress -eq $endpoint.MacAddress }).IPV4Address.IPAddress.Trim()'
       register: source_vip
-
-    - name: Ensure kube-proxy Windows Service is not running
-      win_service:
-        name: "kube-proxy"
-        state: absent
 
     # The bootstrapper runs in one of the above tasks and makes C:\\k\\log directory created before hand
     # Creating a kube-proxy log directory to store kube-proxy specific logs


### PR DESCRIPTION
This PR resolves the access to kube-proxy error encountered while running WSU
playbook multiple times accross the same set of VM's

Problem: WSU playbook fails to run in TASK [Copy kube-proxy to C:\k] with the error
"Access to the path 'C:\\k\\kube-proxy.exe' is denied".

Solution: This is happening because kube-proxy is in use. This is fixed by moving
the `Ensure kube-proxy Windows Service is not running` to execute before the
`Copy kube-proxy to C:\k` task.

Bug: [1809291](https://bugzilla.redhat.com/show_bug.cgi?id=1809291)