### PR TITLE
[wmcb] Dynamically pick the kube-node package in the e2e tests

### DIFF
--- a/internal/test/framework/framework.go
+++ b/internal/test/framework/framework.go
@@ -68,6 +68,8 @@ type TestFramework struct {
 	latestRelease *github.RepositoryRelease
 	// LatestCniPluginsVersion is the latest 0.8.x version of CNI Plugins
 	LatestCniPluginsVersion string
+	// K8sVersion is the current version of Kuberenetes
+	K8sVersion string
 	// clusterAddress is the address of the OpenShift cluster e.g. "foo.fah.com".
 	// This should not include "https://api-" or a port.
 	ClusterAddress string
@@ -244,11 +246,12 @@ func (f *TestFramework) getClusterAddress(config *restclient.Config) error {
 func (f *TestFramework) getClusterVersion() error {
 	versionInfo, err := f.OSConfigClient.Discovery().ServerVersion()
 	if err != nil {
-		return err
+		return fmt.Errorf("error while retrieving k8s version : %v", err)
 	}
-
+	//set k8s version in the TestFrameWork
+	f.K8sVersion = versionInfo.GitVersion
 	// Convert kubernetes version to major.minor format. v1.17.0 -> 1.17
-	k8sVersion := strings.TrimLeft(versionInfo.GitVersion, "v")
+	k8sVersion := strings.TrimLeft(f.K8sVersion, "v")
 	k8sSemver := strings.Split(k8sVersion, ".")
 	k8sMinorVersion, err := strconv.Atoi(k8sSemver[1])
 	if err != nil {

--- a/internal/test/wmcb/pkginfo.go
+++ b/internal/test/wmcb/pkginfo.go
@@ -1,0 +1,157 @@
+package wmcb
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// pkgName is the user defined name of the package
+type pkgName string
+
+//cniPlugins contains information about the CNI plugin package
+type cniPlugins struct {
+	pkgInfo
+}
+
+//hybridOverlay contains information about the hybrid overlay binary
+type hybridOverlay struct {
+	pkgInfo
+}
+
+// PkgInfo is an interface to populate pkgInfo structs
+type PkgInfo interface {
+	//getName returns the user defined package name
+	getName() pkgName
+	//getUrl returns the url of the package
+	getUrl() string
+	//getShaValue returns SHA value for the package
+	getShaValue() (string, error)
+	// getShaType returns SHA type (e.g sha256)
+	getShaType() string
+}
+
+// pkgInfo encapsulates information about a package
+type pkgInfo struct {
+	// name of the package
+	name pkgName
+	// url is the URL of the package
+	url string
+	// sha is the SHA hash of the package
+	sha string
+	// shaType is the type of SHA used, example: 256 or 512
+	shaType string
+}
+
+// pkgInfoFactory returns PkgInfo specific to the package name
+func pkgInfoFactory(name pkgName, shaType string, baseUrl string, version string) (PkgInfo, error) {
+	switch name {
+	case cniPluginPkgName:
+		return newCniPluginPkg(name, shaType, baseUrl, version)
+	case hybridOverlayPkgName:
+		return newHybridOverlayPkg(name, shaType)
+	default:
+		return nil, fmt.Errorf("invalid Package name")
+	}
+}
+
+// newCniPluginPkg returns cniPlugins implementation of PkgInfo interface
+func newCniPluginPkg(name pkgName, shaType string, baseUrl string, version string) (PkgInfo, error) {
+	if version == "" {
+		return nil, fmt.Errorf("latest cni plugins version not specified")
+	}
+	if baseUrl == "" {
+		return nil, fmt.Errorf("base url for cni plugins not specified")
+	}
+	return &cniPlugins{
+		pkgInfo{
+			name:    name,
+			url:     baseUrl + version + "/cni-plugins-windows-amd64-" + version + ".tgz",
+			shaType: shaType,
+		},
+	}, nil
+}
+
+// newHybridOverlayPkg returns hybridOverlay implementation of PkgInfo interface
+func newHybridOverlayPkg(name pkgName, shaType string) (PkgInfo, error) {
+	hybridOverlayUrl, err := framework.GetReleaseArtifactURL(hybridOverlayName)
+	if err != nil {
+		return nil, err
+	}
+	return &hybridOverlay{
+		pkgInfo{
+			name:    name,
+			shaType: shaType,
+			url:     hybridOverlayUrl,
+		},
+	}, nil
+}
+
+// getSHAFileContent returns the contents of the SHA file for the given url of the package.
+func (p *pkgInfo) getShaFileContent() (string, error) {
+	pkgChecksumFileURL := p.url + "." + p.shaType
+	response, err := http.Get(pkgChecksumFileURL)
+	if err != nil {
+		return "", fmt.Errorf("could not fetch content from checksum file: %s", err)
+	}
+	defer response.Body.Close()
+
+	var checksumFileContent string
+	// Fetching checksum file content from the GET Response
+	scanner := bufio.NewScanner(response.Body)
+	for scanner.Scan() {
+		checksumFileContent = scanner.Text()
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error in reading file contents")
+	}
+	return checksumFileContent, nil
+}
+
+// getShaValue returns the sha value of the cni plugins package
+func (c *cniPlugins) getShaValue() (string, error) {
+	if c.sha != "" {
+		return c.sha, nil
+	}
+	checksumFileContent, err := c.getShaFileContent()
+	if err != nil {
+		return "", err
+	}
+	// The checksum file content is in the format "<sha> <filename>". So to get SHA we need to extract only the <sha>
+	// from the file
+	sha512 := strings.Split(checksumFileContent, " ")
+	if len(sha512) < 2 {
+		return "", fmt.Errorf("checksum file content is not in the format : '<sha> <filename>'")
+	}
+	c.sha = sha512[0]
+	return c.sha, nil
+}
+
+// getName returns the user defined name of the package
+func (p *pkgInfo) getName() pkgName {
+	return p.name
+}
+
+//getShaType returns the sha type of the package
+func (p *pkgInfo) getShaType() string {
+	return p.shaType
+}
+
+//getUrl returns the url of the package
+func (p *pkgInfo) getUrl() string {
+	return p.url
+}
+
+//getShaValue returns the SHA value for the hybrid overlay package
+func (h *hybridOverlay) getShaValue() (string, error) {
+	if h.sha != "" {
+		return h.sha, nil
+	}
+	hybridOverlaySHA, err := framework.GetReleaseArtifactSHA(hybridOverlayName)
+	if err != nil {
+		return "", err
+	}
+	h.sha = hybridOverlaySHA
+	return h.sha, nil
+}


### PR DESCRIPTION
This PR consists of 2 commits 

- Create an interface to generalize adding packages in the wmcb tests. Implement Factory pattern to retrieve package specific instances.

- The PR also ensures that tests use kube node package with the current k8s version

    **Problem**: wmcb e2e tests use kube-node packgage with hardcoded version.

   **Solution**: Use current kubernetes version to retrieve node package
   for Windows. The corresponding SHA is retrieved using changelog.

   [WINC-235](https://issues.redhat.com/browse/WINC-235)