### PR TITLE
[ci] Remove script that sets user in wsu e2e

### DIFF
--- a/hack/run-wsu-ci-e2e-test.sh
+++ b/hack/run-wsu-ci-e2e-test.sh
@@ -28,14 +28,6 @@ TEST_DIR=$WMCO_ROOT/internal/test/wsu
 # Make gopath if doesnt exist
 mkdir -p $GOPATH
 
-# If current user cannot be found add it to /etc/passwd. This is the case when this is run by an OpenShift cluster,
-# as OpenShift uses an arbitrarily assigned user ID to run the container.
-if ! whoami; then
-  echo "Creating user"
-  echo "tempuser:x:$(id -u):$(id -g):,,,:${HOME}:/bin/bash" >> /etc/passwd
-  echo "tempuser:x:$(id -G | cut -d' ' -f 2)" >> /etc/group
-fi
-
 # The WSU playbook requires the cluster address, we parse that here using oc
 CLUSTER_ADDR=$(oc cluster-info | head -n1 | sed 's/.*\/\/api.//g'| sed 's/:.*//g')
 


### PR DESCRIPTION
To run our tests in CI, we create the user in the script that sets up
WSU e2e tests. This is done to run our tests in CI, where the cluster
uses arbitrarily assigned user ID to run the container

This is a test PR to see if our tests can pass without the said script,
as this is causing issues when SDN repo is trying to run our tests
in CI