### PR TITLE
Bug 1818026: Redirect WMCB info logs to stdout

### DIFF
--- a/cmd/bootstrapper/configure_cni.go
+++ b/cmd/bootstrapper/configure_cni.go
@@ -66,7 +66,8 @@ func runConfigureCNICmd(cmd *cobra.Command, args []string) {
 		log.Error(err, "could not configure CNI")
 		os.Exit(1)
 	}
-	log.Info("CNI configuration completed successfully")
+	// Send success message to StdOut for WSU to ascertain that CNI configuration was successful
+	os.Stdout.WriteString("CNI configuration completed successfully")
 
 	err = wmcb.Disconnect()
 	if err != nil {

--- a/cmd/bootstrapper/initialize_kubelet.go
+++ b/cmd/bootstrapper/initialize_kubelet.go
@@ -65,7 +65,8 @@ func runInitializeKubeletCmd(cmd *cobra.Command, args []string) {
 		log.Error(err, "could not run bootstrapper")
 		os.Exit(1)
 	} else {
-		log.Info("Bootstrapping completed successfully")
+		// Send success message to StdOut for WSU to ascertain that bootstrapping was successful
+		os.Stdout.WriteString("Bootstrapping completed successfully")
 	}
 
 	err = wmcb.Disconnect()

--- a/cmd/bootstrapper/main.go
+++ b/cmd/bootstrapper/main.go
@@ -24,6 +24,11 @@ var (
 
 func init() {
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+	// Controller-runtime's zap package redirects logs to StdErr by default. Functionality to set up the destination of
+	// logs would require bumping up the version of controller-runtime to at least 0.4.0, which is dependent on
+	// https://issues.redhat.com/browse/WINC-347
+	// Here we set up the logger that sends logs to StdErr. Info level logs should be bubbled up to StdOut instead
+	// WMCO interprets logs in StdErr as an indication that bootstrapping failed
 	logger.SetLogger(zap.New())
 }
 

--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -277,7 +277,7 @@
     - name: Check if bootstrap was successful
       fail:
         msg: "Bootstrapper error"
-      when: '"Bootstrapping completed successfully" not in bootstrap_out.stderr'
+      when: '"Bootstrapping completed successfully" not in bootstrap_out.stdout'
 
     # Making a best effort to approve CSRs. Not failing until the actual `get node` call, in case the CSRs were approved elsewhere
     - name: Approve CSRs
@@ -428,7 +428,7 @@
     - name: Check if CNI configuration was successful
       fail:
         msg: "CNI Configuration error"
-      when: '"CNI configuration completed successfully" not in bootstrap_out.stderr'
+      when: '"CNI configuration completed successfully" not in bootstrap_out.stdout'
 
     - name: Ensure kube-proxy Windows Service is not running
       win_service:


### PR DESCRIPTION
Currently, all WMCB logs are redirected to stderr by [default](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/log/zap#Options), including info level logs. This PR redirects info level logs to stdout and errors are redirected to stderr.

As a part of this PR:
- wmcb code changes for redirecting info logs to stdout and errors to stderr
- wsu changes to react to wmcb changes