### PR TITLE
Bug 1821429: [wsu] Fix getting kube node binary SHA

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -10,10 +10,10 @@ COPY . .
 RUN yum -y update && yum -y install git make python2 python2-pip gcc jq
 
 # Download and install Go
-RUN curl -L -s https://dl.google.com/go/go1.12.13.linux-amd64.tar.gz > go1.12.13.linux-amd64.tar.gz \
-    && sha256sum go1.12.13.linux-amd64.tar.gz \
-    && echo "da036454cb3353f9f507f0ceed4048feac611065e4e1818b434365eb32ac9bdc go1.12.13.linux-amd64.tar.gz" | sha256sum -c \
-    && tar -xzf go1.12.13.linux-amd64.tar.gz \
+RUN curl -L -s https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz > go1.13.8.linux-amd64.tar.gz \
+    && sha256sum go1.13.8.linux-amd64.tar.gz \
+    && echo "0567734d558aef19112f2b2873caa0c600f1b4a5827930eb5a7f35235219e9d8 go1.13.8.linux-amd64.tar.gz" | sha256sum -c \
+    && tar -xzf go1.13.8.linux-amd64.tar.gz \
     && mv go /usr/local \
     && rm -rf ./go*
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ GO_BUILD_ARGS=CGO_ENABLED=0 GO111MODULE=on
 # TODO (suhanime): Pin go versions and lint
 # TODO (suhanime): Enable linting when we don't have unimplemented methods
 
+# The golang 1.13 image used in CI enforces vendoring. Workaround that by unsetting it.
+ifeq ($(GOFLAGS), -mod=vendor)
+	unexport GOFLAGS
+endif
+
 .PHONY: build
 build:
 	$(GO_BUILD_ARGS) GOOS=windows go build -o wmcb.exe  $(MAIN_PACKAGE)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/windows-machine-config-bootstrapper
 
-go 1.12
+go 1.13
 
 // Replace is used to pin a specific version of a package or to point to sub-go.mod directories.
 // Use 'replace' to point to the sub-go.mod directory for building a binary in the root directory and always build by

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -5,7 +5,7 @@ WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.10|go1.11|go1.12') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.10|go1.11|go1.12|go1.13') ]]; then
   echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
   exit 1
 fi

--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -28,7 +28,7 @@
 
     # kubernetes_version v1.17.2 should correspond to 1.17 for getting changelog url
     - name: Get kubernetes version without patch version
-      shell: "version={{ kubernetes_version.stdout }} ; echo ${version%.*} | tr -d v"
+      shell: "version={{ kubernetes_version.stdout }} ; baseVersion=${version%-*} ; echo ${baseVersion%.*}  | tr -d v"
       register: kubernetes_version_without_patch
       failed_when: kubernetes_version_without_patch.stdout == ""
 

--- a/tools/windows-node-installer/go.mod
+++ b/tools/windows-node-installer/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer
 
-go 1.12
+go 1.13
 
 replace (
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200205145930-e9d93e317dd1 // OpenShift 4.3


### PR DESCRIPTION
This PR fixes the shell command for extracting the kubernetes version without patch version for any
intermediate releases eg: v1.18.0-rc.1 should be extracted as 1.18 instead of 1.18.0-rc for forming
the changelog URL.
In addition it also makes the changes necessary in go.mod, verify-gofmt.sh and Dockerfile to update golang version from 1.12 to 1.13. 
Since the golang version has been updated in CI we need to unset the GOFLAGS environment variable where it is set to "-mod=vendor" value to avoid vendoring in CI environment.