### PR TITLE
[wsu] get node name from public or private ip

### DIFF
--- a/internal/test/wsu/wsu_test.go
+++ b/internal/test/wsu/wsu_test.go
@@ -87,11 +87,19 @@ func createHostFile(vmList []e2ef.TestWindowsVM) (string, error) {
 	}
 	defer hostFile.Close()
 
+	// Give a loop back ip as internal ip, this would never show up as
+	// private ip for any cloud provider. This is a dummy for testing purposes.
+	// This is a hack to avoid changes to the Credentials struct or
+	// making cloud provider API calls at this juncture and it would need to be fixed
+	// if we ever want to add Azure e2e tests.
+	loopbackIP := "127.0.0.1"
+
 	// Add each host to the host file
 	hostFileContents := "[win]\n"
 	for i := 0; i < len(vmList); i++ {
 		creds := vmList[i].GetCredentials()
-		hostFileContents += creds.GetIPAddress() + " " + "ansible_password='" + creds.GetPassword() + "'" + "\n"
+		hostFileContents += creds.GetIPAddress() + " " + "ansible_password='" + creds.GetPassword() + "'" +
+			" " + "private_ip='" + loopbackIP + "'" + "\n"
 	}
 
 	// Add the common variables

--- a/tools/ansible/README.md
+++ b/tools/ansible/README.md
@@ -17,8 +17,8 @@ pip install selinux ansible==2.9 pywinrm
 - A `hosts` file with the required variables defined. See below for an example:
 ```
 [win]
-# Address of a node and its Windows password
-<node_ip> ansible_password=<password>
+# Public ip address of a node and its Windows password and private ip 
+<public_ip> ansible_password=<password> private_ip=<private_ip>
 
 [win:vars]
 # Windows username, typically 'Administrator'

--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -325,7 +325,7 @@
     # TODO: Move this to a more deterministic way of identifying the node we just bootstrapped
     - name: Get bootstrapped node name
       delegate_to: localhost
-      shell: "oc get node -o wide |awk '/{{ inventory_hostname }}/ {print $1}'"
+      shell: "oc get node -o wide |awk '/{{ inventory_hostname }}/ || /{{ private_ip }}/ {print $1}'"
       register: node_name
       until: node_name.stdout != ""
       retries: 3

--- a/tools/windows-node-installer/test/e2e/azure_test.go
+++ b/tools/windows-node-installer/test/e2e/azure_test.go
@@ -333,13 +333,21 @@ func createHostFile(ip, password string) (string, error) {
 	}
 	defer hostFile.Close()
 
+	// Give a loop back ip as internal ip, this would never show up as
+	// private ip for any cloud provider. This is a dummy value for testing
+	// purposes. This is a hack to avoid changes to the Credentials struct or
+	// making cloud provider API calls at this juncture and it would need to be fixed
+	// if we ever want to add Azure e2e tests.
+	// TODO: Remove this and get the ip address from the cloud provider
+	// 		 using instance ID from the node object
+	loopbackIP := "127.0.0.1"
 	_, err = hostFile.WriteString(fmt.Sprintf(`[win]
-%s ansible_password=%s
+%s ansible_password=%s private_ip=%s
 [win:vars]
 ansible_user=core
 ansible_port=%s
 ansible_connection=winrm
-ansible_winrm_server_cert_validation=ignore`, ip, password, winRMPort))
+ansible_winrm_server_cert_validation=ignore`, ip, password, loopbackIP, winRMPort))
 	return hostFile.Name(), err
 }
 


### PR DESCRIPTION
this commit changes the wsu to get the node name
from private ip of the vm if the public ip doesn't
exist

Co-authored-by: pratikmahajan <pratik@mahajan.xyz>

Taken from https://github.com/PratikMahajan/windows-machine-config-bootstrapper/commit/57e707510dad4f4a7d38d599da1ef522bf4895dc

