### PR TITLE
[wni] Update Reinitialize() to handle WinRM client

### DIFF
--- a/tools/windows-node-installer/pkg/types/types.go
+++ b/tools/windows-node-installer/pkg/types/types.go
@@ -157,6 +157,9 @@ func (w *Windows) Reinitialize() error {
 	if err := w.GetSSHClient(); err != nil {
 		return fmt.Errorf("failed to reinitialize ssh client: %v", err)
 	}
+	if err := w.SetupWinRMClient(); err != nil {
+		return fmt.Errorf("failed to reinitialize WinRM client: %v", err)
+	}
 	return nil
 }
 
@@ -218,7 +221,7 @@ func (w *Windows) GetSSHClient() error {
 	if w.SSHClient != nil {
 		// Close the existing client to be on the safe side
 		if err := w.SSHClient.Close(); err != nil {
-			log.Printf("error closing ssh client connection: %v", err)
+			log.Printf("warning - error closing ssh client connection: %v", err)
 		}
 	}
 


### PR DESCRIPTION
We are noticing that commands run using Run() that uses a WinRM client is taking more than 5 minutes to complete after the hybrid-overlay reconfigures the network. Reinitialize the WinRM client in the Reinitialize() method to mitigate this.

Add a "warning" pre-fix to the log message printed on errors encountered when reinitialzing the SSH client to call out that this is not a fatal error.