### PR TITLE
[wni] Fix unresolved ssh port in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: build build-tools build-wmcb-unit-test build-wmcb-e2e-test verify-all
+all: build build-tools build-wmcb-unit-test build-wmcb-e2e-test test-unit-wni verify-all
 
 PACKAGE=github.com/openshift/windows-machine-config-bootstrapper
 MAIN_PACKAGE=$(PACKAGE)/cmd/bootstrapper
@@ -33,6 +33,10 @@ test-e2e-prepared-node:
 .PHONY: build-tools
 build-tools:
 	cd ./tools/windows-node-installer && $(GO_BUILD_ARGS) go build -o wni $(TOOLS_DIR)
+
+.PHONY: test-unit-wni
+test-unit-wni:
+	cd ./tools/windows-node-installer && $(GO_BUILD_ARGS) go test  $(TOOLS_DIR)/pkg/...  -v -count=1
 
 .PHONY: test-e2e-tools
 test-e2e-tools:

--- a/tools/windows-node-installer/pkg/cloudprovider/aws/ec2_test.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/aws/ec2_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -89,7 +90,7 @@ func TestGetRulesForSgUpdate(t *testing.T) {
 			expected: []*ec2.IpPermission{
 				getAllPortRule(vpcCidr),
 				getOtherPortRules(WINRM_PORT, myIP),
-				getOtherPortRules(sshPort, myIP),
+				getOtherPortRules(types.SshPort, myIP),
 				getOtherPortRules(rdpPort, myIP),
 			},
 		},
@@ -101,7 +102,7 @@ func TestGetRulesForSgUpdate(t *testing.T) {
 			},
 			expected: []*ec2.IpPermission{
 				getAllPortRule(vpcCidr),
-				getOtherPortRules(sshPort, myIP),
+				getOtherPortRules(types.SshPort, myIP),
 				getOtherPortRules(rdpPort, myIP),
 			},
 		},
@@ -110,7 +111,7 @@ func TestGetRulesForSgUpdate(t *testing.T) {
 			name: "Complete input from current IP",
 			in: []*ec2.IpPermission{
 				getOtherPortRules(WINRM_PORT, myIP),
-				getOtherPortRules(sshPort, myIP),
+				getOtherPortRules(types.SshPort, myIP),
 				getOtherPortRules(rdpPort, myIP),
 			},
 			expected: []*ec2.IpPermission{
@@ -126,7 +127,7 @@ func TestGetRulesForSgUpdate(t *testing.T) {
 			},
 			expected: []*ec2.IpPermission{
 				getOtherPortRules(WINRM_PORT, myIP),
-				getOtherPortRules(sshPort, myIP),
+				getOtherPortRules(types.SshPort, myIP),
 				getOtherPortRules(rdpPort, myIP),
 			},
 		},
@@ -136,12 +137,12 @@ func TestGetRulesForSgUpdate(t *testing.T) {
 			in: []*ec2.IpPermission{
 				getAllPortRule(vpcCidr),
 				getOtherPortRules(WINRM_PORT, otherIP),
-				getOtherPortRules(sshPort, otherIP),
+				getOtherPortRules(types.SshPort, otherIP),
 				getOtherPortRules(rdpPort, otherIP),
 			},
 			expected: []*ec2.IpPermission{
 				getOtherPortRules(WINRM_PORT, myIP),
-				getOtherPortRules(sshPort, myIP),
+				getOtherPortRules(types.SshPort, myIP),
 				getOtherPortRules(rdpPort, myIP),
 			},
 		},


### PR DESCRIPTION
https://github.com/openshift/windows-machine-config-bootstrapper/pull/165/commits/48d69e8bd2b2801c42ab7c299a41cbf03d6a46a7 introduced the change which broke the unit tests. This commit ensures aws unit tests pass now

/cc @PratikMahajan @aravindhp @openshift/openshift-team-windows-containers 