### PR TITLE
[wni] Return error on AWS instance state changes during CreateWindowsVM call

### DIFF
--- a/tools/windows-node-installer/pkg/cloudprovider/aws/ec2.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/aws/ec2.go
@@ -307,6 +307,19 @@ func (a *AwsProvider) DestroyWindowsVM(instanceID string) error {
 	return nil
 }
 
+// IsVMRunning checks if the VM is in running state currently and then returns failure
+func (a *AwsProvider) IsVMRunning(instanceID string) error {
+	// Check if the instance exists, if not no need to wait return immediately
+	instance, err := a.GetInstance(instanceID)
+	if err != nil {
+		return fmt.Errorf("instance retrieval failed with: %v", err)
+	}
+	if *instance.State.Name != ec2.InstanceStateNameRunning {
+		return fmt.Errorf("instance is in %s state", *instance.State.Name)
+	}
+	return nil
+}
+
 // waitUntilPasswordDataIsAvailable waits till the ec2 password data is available.
 // AWS sdk's WaitUntilPasswordDataAvailable is returning inspite of password data being available.
 // So, building this function as a wrapper around AWS sdk's GetPasswordData method with constant back-off
@@ -316,6 +329,9 @@ func (a *AwsProvider) waitUntilPasswordDataIsAvailable(instanceID string) (*ec2.
 		currTime := time.Since(startTime)
 		if currTime >= awsPasswordDataTimeOut {
 			return nil, fmt.Errorf("timed out waiting for password to be available")
+		}
+		if err := a.IsVMRunning(instanceID); err != nil {
+			return nil, err
 		}
 		// Get the ec2 passworddata output.
 		pwdData, err := a.getPasswordDataOutput(instanceID)

--- a/tools/windows-node-installer/pkg/cloudprovider/aws/ec2.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/aws/ec2.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/client"
 	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/resource"
@@ -64,7 +65,7 @@ type AwsProvider struct {
 	// using this flag. AWS encrypts the password of the Windows instance created with this public key
 	sshKey string
 	// A client for EC2.
-	EC2 *ec2.EC2
+	EC2 ec2iface.EC2API
 	// A client for IAM.
 	IAM *iam.IAM
 	// openShiftClient is the client of the existing OpenShift cluster.

--- a/tools/windows-node-installer/pkg/cloudprovider/aws/ec2_test.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/aws/ec2_test.go
@@ -5,15 +5,59 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
+type mockEC2Client struct {
+	ec2iface.EC2API
+}
+
+type Instance struct {
+	name         string
+	passwordData string
+	state        string
+}
+
 var (
-	awsProvider = AwsProvider{}
+	mockClient         = &mockEC2Client{}
+	awsProvider        = AwsProvider{EC2: mockClient}
+	runningInstance    = Instance{name: "RunningInstance", passwordData: "abc123", state: ec2.InstanceStateNameRunning}
+	terminatedInstance = Instance{name: "terminatedInstance", state: ec2.InstanceStateNameTerminated}
 )
+
+func (m *mockEC2Client) GetPasswordData(instanceDataInput *ec2.GetPasswordDataInput) (*ec2.GetPasswordDataOutput, error) {
+	instanceId := *instanceDataInput.InstanceId
+	if instanceId == runningInstance.name {
+		return &ec2.GetPasswordDataOutput{
+			InstanceId:   &runningInstance.name,
+			PasswordData: &runningInstance.passwordData,
+		}, nil
+	}
+	return nil, nil
+}
+
+func (m *mockEC2Client) DescribeInstances(instanceInput *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+	if len(instanceInput.InstanceIds) > 0 {
+		return nil, fmt.Errorf("expected only one instance to be available for testing")
+	}
+	instanceId := *instanceInput.InstanceIds[0]
+	if instanceId == runningInstance.name {
+		return &ec2.DescribeInstancesOutput{
+			Reservations: []*ec2.Reservation{{Instances: []*ec2.Instance{{InstanceId: &instanceId, State: &ec2.InstanceState{Name: &runningInstance.state}}}}},
+		}, nil
+	}
+	if instanceId == terminatedInstance.name {
+		return &ec2.DescribeInstancesOutput{
+			Reservations: []*ec2.Reservation{{Instances: []*ec2.Instance{{InstanceId: &instanceId, State: &ec2.InstanceState{Name: &terminatedInstance.state}}}}},
+		}, nil
+	}
+	return nil, nil
+}
 
 // generateKeyPair generates a new key pair
 func generateKeyPair() (*rsa.PrivateKey, *rsa.PublicKey) {
@@ -151,5 +195,38 @@ func TestGetRulesForSgUpdate(t *testing.T) {
 	for _, tt := range testIO {
 		actual := awsProvider.getRulesForSgUpdate(myIP, tt.in, vpcCidr)
 		assert.ElementsMatch(t, tt.expected, actual, tt.name, "awsProvider.getRulesForSgUpdate(), actual values do not match expected")
+	}
+}
+
+func TestAwsProvider_waitUntilPasswordDataIsAvailable(t *testing.T) {
+	tests := []struct {
+		name       string
+		instanceID string
+		want       *ec2.GetPasswordDataOutput
+		wantErr    bool
+	}{
+		{
+			// We should get password only for running instance
+			name:       "Running Instance",
+			instanceID: runningInstance.name,
+			wantErr:    false,
+			want: &ec2.GetPasswordDataOutput{
+				InstanceId:   &runningInstance.name,
+				PasswordData: &runningInstance.passwordData,
+			},
+		},
+		{
+			name:       "Terminated Instance",
+			instanceID: terminatedInstance.name,
+			wantErr:    true,
+			want:       nil,
+		},
+	}
+	for _, tt := range tests {
+		got, err := awsProvider.waitUntilPasswordDataIsAvailable(tt.instanceID)
+		if (err != nil) != tt.wantErr {
+			assert.NoError(t, err, tt.wantErr)
+		}
+		assert.Equal(t, got, tt.want)
 	}
 }


### PR DESCRIPTION
This PR has 2 commits:
0856135 - Switches to using ec2 inteface which makes mocking easier
2fdb7ef - Return immediately from the CreateWindowsVM when the instance is not running instead of waiting till timeout