### PR TITLE
[ci] Remove dependency on oc binary

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -17,15 +17,6 @@ RUN curl -L -s https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz > go1.13.8.l
     && mv go /usr/local \
     && rm -rf ./go*
 
-# Download and install oc
-RUN curl -L -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.2.2/openshift-client-linux-4.2.2.tar.gz -o openshift-origin-client-tools.tar.gz \
-    && echo "8f853477fa99cfc4087ad2ddf9b13b9d22e5fc4d5dc24c63ec5b0a91bb337fc9 openshift-origin-client-tools.tar.gz" | sha256sum -c \
-    && tar -xzf openshift-origin-client-tools.tar.gz \
-    && mv oc /usr/bin/oc \
-    && mv kubectl /usr/bin/kubectl \
-    && rm -rf ./openshift* \
-    && oc version
-
 # Install ansible and required packages
 RUN pip2 install ansible pywinrm
 

--- a/hack/run-wmcb-ci-e2e-test.sh
+++ b/hack/run-wmcb-ci-e2e-test.sh
@@ -31,12 +31,6 @@ make build-wmcb-unit-test
 make build-wmcb-e2e-test
 
 
-# Set up hybrid networking on the cluster, a requirement of OVNKubernetes on Windows
-oc patch network.operator cluster --type=merge -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"hybridOverlayConfig":{"hybridClusterNetwork":[{"cidr":"10.132.0.0/14","hostPrefix":23}]}}}}}'
-
-# The WMCB E2E tests requires the cluster address, we parse that here using oc
-CLUSTER_ADDR=$(oc cluster-info | head -n1 | sed 's/.*\/\/api.//g'| sed 's/:.*//g')
-
 cd "${WMCB_TEST_DIR}"
 # Transfer the files and run the unit and e2e tests
-CGO_ENABLED=0 GO111MODULE=on CLUSTER_ADDR=$CLUSTER_ADDR go test -v -run=TestWMCB -filesToBeTransferred="../../../wmcb_unit_test.exe,../../../wmcb_e2e_test.exe,powershell/wget-ignore-cert.ps1" -vmCreds="$VM_CREDS" $SKIP_VM_SETUP -timeout=30m .
+CGO_ENABLED=0 GO111MODULE=on go test -v -run=TestWMCB -filesToBeTransferred="../../../wmcb_unit_test.exe,../../../wmcb_e2e_test.exe,powershell/wget-ignore-cert.ps1" -vmCreds="$VM_CREDS" $SKIP_VM_SETUP -timeout=30m .

--- a/hack/run-wsu-ci-e2e-test.sh
+++ b/hack/run-wsu-ci-e2e-test.sh
@@ -36,14 +36,11 @@ if ! whoami; then
   echo "tempuser:x:$(id -G | cut -d' ' -f 2)" >> /etc/group
 fi
 
-# The WSU playbook requires the cluster address, we parse that here using oc
-CLUSTER_ADDR=$(oc cluster-info | head -n1 | sed 's/.*\/\/api.//g'| sed 's/:.*//g')
-
 # Even though the above patch will take non-zero time to apply, no delay is needed, as the WSU test suite
 # begins by creating a VM, an action which will take 4+ minutes. More than enough time for the patch to apply.
 
 # Run the test suite
 cd $TEST_DIR
-GO_BUILD_ARGS=CGO_ENABLED=0 GO111MODULE=on CLUSTER_ADDR=$CLUSTER_ADDR WSU_PATH=$WMCO_ROOT/tools/ansible/tasks/wsu/main.yaml go test -v -vmCreds="$VM_CREDS" $SKIP_VM_SETUP -timeout 60m .
+GO_BUILD_ARGS=CGO_ENABLED=0 GO111MODULE=on WSU_PATH=$WMCO_ROOT/tools/ansible/tasks/wsu/main.yaml go test -v -vmCreds="$VM_CREDS" $SKIP_VM_SETUP -timeout 60m .
 
 exit 0

--- a/internal/test/wmcb/wmcb_test.go
+++ b/internal/test/wmcb/wmcb_test.go
@@ -212,7 +212,7 @@ func (vm *wmcbVM) initializeTestBootstrapperFiles() error {
 	}
 
 	// Download the worker ignition to C:\Windows\Tenp\ using the script that ignores the server cert
-	_, _, err = vm.Run(wgetIgnoreCertCmd+" -server https://api-int."+e2ef.ClusterAddress+":22623/config/worker"+" -output "+winTemp+"worker.ign", true)
+	_, _, err = vm.Run(wgetIgnoreCertCmd+" -server https://api-int."+framework.ClusterAddress+":22623/config/worker"+" -output "+winTemp+"worker.ign", true)
 	if err != nil {
 		return fmt.Errorf("unable to download worker.ign: %v", err)
 	}

--- a/internal/test/wsu/wsu_test.go
+++ b/internal/test/wsu/wsu_test.go
@@ -109,7 +109,7 @@ cluster_address=%s
 ansible_port=5986
 ansible_connection=winrm
 ansible_winrm_server_cert_validation=ignore
-`, e2ef.ClusterAddress)
+`, framework.ClusterAddress)
 	_, err = hostFile.WriteString(hostFileContents)
 	return hostFile.Name(), err
 }


### PR DESCRIPTION
The oc binary is no longer injected into src image in the CI step registry world. There is no reason for us to use oc when we can achieve the same functionality using the API.
- Get the cluster address using API calls
- Removing patching of the network.operator CR as this needs to be  removed anyhow.

This is needed for https://github.com/openshift/release/pull/8623/

Based on openshift/windows-machine-config-operator#47
Co-authored-by: ravisantoshgudimetla <ravisantoshgudimetla@gmail.com>