### PR TITLE
[ci] Fix DEFAULT_LOCAL_TMP env var

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -30,6 +30,6 @@ RUN chmod -R g=u+w /go
 ENV GOCACHE="/go/.cache"
 ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GOPATH="/go"
-ENV DEFAULT_LOCAL_TMP="/tmp"
+ENV ANSIBLE_LOCAL_TEMP="/tmp"
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -23,6 +23,11 @@ RUN pip2 install ansible pywinrm
 # Make Ansible happy with arbitrary UID/GID in OpenShift.
 RUN chmod g=u /etc/passwd /etc/group
 
+# Seems ansible-playbook doesn't work with ansible.cfg
+RUN mkdir -p /.ansible
+RUN chmod 777 -R /.ansible
+
+
 # Allow building the WMCB and creation of /go/.cache directory
 RUN chmod -R g=u+w /go
 

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -30,5 +30,6 @@ RUN chmod -R g=u+w /go
 ENV GOCACHE="/go/.cache"
 ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GOPATH="/go"
+ENV DEFAULT_LOCAL_TMP="/tmp"
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/hack/run-wsu-ci-e2e-test.sh
+++ b/hack/run-wsu-ci-e2e-test.sh
@@ -28,9 +28,6 @@ TEST_DIR=$WMCO_ROOT/internal/test/wsu
 # Make gopath if doesnt exist
 mkdir -p $GOPATH
 
-# Seems ansible-playbook doesn't work with ansible.cfg
-mkdir -p /.ansible
-chmod 777 -R /.ansible
 
 # If current user cannot be found add it to /etc/passwd. This is the case when this is run by an OpenShift cluster,
 # as OpenShift uses an arbitrarily assigned user ID to run the container.

--- a/hack/run-wsu-ci-e2e-test.sh
+++ b/hack/run-wsu-ci-e2e-test.sh
@@ -28,6 +28,10 @@ TEST_DIR=$WMCO_ROOT/internal/test/wsu
 # Make gopath if doesnt exist
 mkdir -p $GOPATH
 
+# Seems ansible-playbook doesn't work with ansible.cfg
+mkdir -p /.ansible
+chmod 777 -R /.ansible
+
 # If current user cannot be found add it to /etc/passwd. This is the case when this is run by an OpenShift cluster,
 # as OpenShift uses an arbitrarily assigned user ID to run the container.
 if ! whoami; then


### PR DESCRIPTION
The CI's env var for ansible tmp is not
pointing to the user's home we create
in Dockerfile.tools but it is pointing to "/"
causing our CI to fail. This commit ensures
that we're using `/tmp` as the temporary
dir for our ansible playbook.

