### PR TITLE
[ci] Step registry fixes

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -17,11 +17,23 @@ RUN curl -L -s https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz > go1.13.8.l
     && mv go /usr/local \
     && rm -rf ./go*
 
+# Download and install oc
+RUN curl -L -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.2.2/openshift-client-linux-4.2.2.tar.gz -o openshift-origin-client-tools.tar.gz \
+    && echo "8f853477fa99cfc4087ad2ddf9b13b9d22e5fc4d5dc24c63ec5b0a91bb337fc9 openshift-origin-client-tools.tar.gz" | sha256sum -c \
+    && tar -xzf openshift-origin-client-tools.tar.gz \
+    && mv oc /usr/bin/oc \
+    && mv kubectl /usr/bin/kubectl \
+    && rm -rf ./openshift* \
+    && oc version
+
 # Install ansible and required packages
 RUN pip2 install ansible pywinrm
 
 # Make Ansible happy with arbitrary UID/GID in OpenShift.
 RUN chmod g=u /etc/passwd /etc/group
+
+RUN mkdir -p /.ansible
+RUN chmod -R g=u+w /.ansible
 
 # Allow building the WMCB and creation of /go/.cache directory
 RUN chmod -R g=u+w /go
@@ -30,5 +42,6 @@ RUN chmod -R g=u+w /go
 ENV GOCACHE="/go/.cache"
 ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GOPATH="/go"
+ENV ANSIBLE_LOCAL_TEMP="/tmp"
 
 ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
- Bring back downloading and installing oc in Dockerfile.tools. This is   needed by the WSU playbook and was erroneously removed in #192.
- Create Ansible tmp directory with user accessible permissions.