### PR TITLE
Bug 1841140: fix getting kube node binary SHA

### DIFF
--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -22,7 +22,7 @@
 
     # Expected value of kubernetes_version in the form of 'v1.17.2'
     - name: Get kubernetes version
-      shell: "oc version -o json | jq -r '.serverVersion.gitVersion'"
+      shell: "oc version -o json | jq -r '.serverVersion.gitVersion' | cut -d '+' -f1"
       register: kubernetes_version
       failed_when: kubernetes_version.stdout == ""
 
@@ -46,7 +46,7 @@
       shell: |
         curl -s "{{ changelog.stdout }}" | \
         grep -A 1 "{{ kubernetes_version.stdout }}" | \
-        grep -A 1 node-windows | tail -n 1 | sed -e 's/.*<code>\(.*\)<\/code>.*/\1/'
+        grep -A 1 node-windows | tail -n 1 | sed -e 's/.*<code>\(.*\)<\/code>.*/\1/'| sed -e 's/.*<td>\(.*\)<\/td>.*/\1/'
       register: kube_node_sha
       failed_when: kube_node_sha.stdout == ""
 


### PR DESCRIPTION
This PR fixes two issues encountered while running
WSU with kube version v1.18.3+144c666. The redundant
part in the kube version needs to be trimmed to get the
correct kubernetes version in the grep command.
In addition, since the output of the curl command is no
longer in `<td><code>...</code></td>` format but in
`<td>...</td>` format the sha needs to be extracted
accordingly.