### PR TITLE
Bug 1778714: [docs] Call out kubeconfig path usage

### DIFF
--- a/tools/ansible/README.md
+++ b/tools/ansible/README.md
@@ -9,7 +9,7 @@
       - You can find the infraID in the Ignition config file metadata `metadata.json`
 - Ansible 2.9 and pywinrm installed, and selinux bindings exist on the system
 - [oc](https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html) is installed
-- The KUBECONFIG environment variable is set to the cluster's kubeconfig location
+- The KUBECONFIG environment variable is set to the cluster's kubeconfig location using the absolute path
 ```
 sudo dnf install libselinux-python
 pip install selinux ansible==2.9 pywinrm

--- a/tools/ansible/docs/ocp-4-4-with-windows-server.md
+++ b/tools/ansible/docs/ocp-4-4-with-windows-server.md
@@ -179,6 +179,8 @@ Export the `kubeconfig` so that oc can communicate with the cluster:
 $ export KUBECONFIG=$(pwd)/<cluster_directory>/auth/kubeconfig
 ```
 
+**Note**: Only using the absolute path is supported.
+
 Make sure you can interact with the cluster: 
 
 ```sh


### PR DESCRIPTION
We only support using the absolute path in the kubeconfig environment variable for the WSU playbook. Specifying the relative path will cause the playbook to fail.