### PR TITLE
[wni] Expand Cloud interface

### DIFF
--- a/tools/windows-node-installer/pkg/cloudprovider/azure/vm.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/azure/vm.go
@@ -900,6 +900,13 @@ func (az *AzureProvider) constructNetworkProfile(ctx context.Context,
 	return networkProfile, nil
 }
 
+// CreateWindowsVMWithPrivateSubnet creates a WindowsVM within private subnet.
+// TODO: As of now, this is a dummy implementation. If we don't move to the machine-api quickly come back and implement
+// this
+func (az *AzureProvider) CreateWindowsVMWithPrivateSubnet() (windowsVM types.WindowsVM, err error) {
+	return nil, nil
+}
+
 // CreateWindowsVM takes in imageId, instanceType and sshKey name to create Windows instance under the same
 // resourceGroupName as the existing OpenShift. The returned Windows VM object from this method will provide access
 // to the instance via Winrm, SSH

--- a/tools/windows-node-installer/pkg/cloudprovider/factory.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/factory.go
@@ -19,6 +19,8 @@ import (
 type Cloud interface {
 	// CreateWindowsVM creates a Windows VM for a given cloud provider
 	CreateWindowsVM() (types.WindowsVM, error)
+	// CreateWindowsVMWithPrivateSubnet creates a Windows VM for a given cloud provider in a private subnet
+	CreateWindowsVMWithPrivateSubnet() (windowsVM types.WindowsVM, err error)
 	// DestroyWindowsVMs uses 'windows-node-installer.json' file that contains IDs of created instance and
 	// security group and deletes them.
 	// Example 'windows-node-installer.json' file:


### PR DESCRIPTION
As of now, we're using CreateWindowsVM which couples Windows VMs creation along
with attaching it to public subnet. This will not be ideal to us when we are
moving to machine-api in the WMCO world. Machine-api allows the VM to be created
only on the private interface. So, in order to mimick that functionality, this
commit expands the Cloud interface with a method called
CreateWindowsVMWithPrivateIP which allows the WindowsVMs to be created on the
private subnet and won't attach a public IP to the VM created.