### PR TITLE
[wsu] [ci] Add user-agent for ignition url

### DIFF
--- a/internal/test/wmcb/powershell/wget-ignore-cert.ps1
+++ b/internal/test/wmcb/powershell/wget-ignore-cert.ps1
@@ -1,7 +1,8 @@
 # Script that downloads a file from the server to the output location ignoring the server certificate
 param (
     [Parameter(Mandatory=$true)][string]$server,
-    [Parameter(Mandatory=$true)][string]$output
+    [Parameter(Mandatory=$true)][string]$output,
+    [Parameter(Mandatory=$true)][string]$useragent
 )
 
 if (-not("dummy" -as [type])) {
@@ -23,4 +24,4 @@ public static class Dummy {
 }
 [System.Net.ServicePointManager]::ServerCertificateValidationCallback = [dummy]::GetDelegate()
 
-wget $server -o $output
+wget -UserAgent $useragent $server -o $output

--- a/internal/test/wmcb/wmcb_test.go
+++ b/internal/test/wmcb/wmcb_test.go
@@ -233,8 +233,11 @@ func (vm *wmcbVM) initializeTestBootstrapperFiles() error {
 		return fmt.Errorf("unable to copy kubelet.exe to %s", winTemp)
 	}
 
+	// The 0.35.0 maps to ignition spec v2. This should be modified when we switch to v3
+	ignitionUserAgentSpec := "Ignition/0.35.0"
 	// Download the worker ignition to C:\Windows\Tenp\ using the script that ignores the server cert
-	_, _, err = vm.Run(wgetIgnoreCertCmd+" -server https://api-int."+framework.ClusterAddress+":22623/config/worker"+" -output "+winTemp+"worker.ign", true)
+	_, _, err = vm.Run(wgetIgnoreCertCmd+" -server https://api-int."+framework.ClusterAddress+":22623/config/worker"+
+		" -output "+winTemp+"worker.ign"+" -useragent "+ignitionUserAgentSpec, true)
 	if err != nil {
 		return fmt.Errorf("unable to download worker.ign: %v", err)
 	}

--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -256,6 +256,7 @@
       win_get_url:
         url: "https://api-int.{{ cluster_address }}:22623/config/worker"
         dest: "{{ win_temp_dir.path }}\\worker.ign"
+        http_agent: "Ignition/0.35.0"
         validate_certs: no
 
     - name: Get hybrid overlay exe


### PR DESCRIPTION
The MCO team have started moving to ignition v3 spec in MCS. For 4.6 timeframe,
they are supporting both v2 and v3. As a result, MCS now requires user-agent
in the header to tell which version of ignition spec to be served by MCS.
This PR modifies the powershell script to include a new parameter for the
user-agent header