### PR TITLE
[e2e] Remove hybrid-overlay/kubelet release deps

### DIFF
--- a/hack/run-wmcb-ci-e2e-test.sh
+++ b/hack/run-wmcb-ci-e2e-test.sh
@@ -3,6 +3,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+RELEASE="release-4.6"
+GIT_CLONE="git clone --branch $RELEASE --single-branch"
 SKIP_VM_SETUP=""
 VM_CREDS=""
 
@@ -25,6 +27,25 @@ done
 WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 WMCB_TEST_DIR=$WMCO_ROOT/internal/test/wmcb
 
+# Create a temporary directory for the repos
+TMP_DIR=$(mktemp -d)
+trap "rm -rf $TMP_DIR" EXIT
+
+pushd "$TMP_DIR"
+# Build hybrid-overlay-node.exe
+$GIT_CLONE https://github.com/openshift/ovn-kubernetes.git
+cd ovn-kubernetes/go-controller/
+make windows
+HYBRID_OVERLAY_BIN=$TMP_DIR"/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe"
+
+# Build kubelet.exe
+cd "$TMP_DIR"
+$GIT_CLONE https://github.com/openshift/kubernetes.git
+cd kubernetes
+KUBE_BUILD_PLATFORMS=windows/amd64 make WHAT=cmd/kubelet
+KUBELET_BIN=$TMP_DIR"/kubernetes/_output/local/bin/windows/amd64/kubelet.exe"
+popd
+
 # Build the unit test binary
 cd "${WMCO_ROOT}"
 make build-wmcb-unit-test
@@ -33,4 +54,6 @@ make build-wmcb-e2e-test
 
 cd "${WMCB_TEST_DIR}"
 # Transfer the files and run the unit and e2e tests
-CGO_ENABLED=0 GO111MODULE=on go test -v -run=TestWMCB -filesToBeTransferred="../../../wmcb_unit_test.exe,../../../wmcb_e2e_test.exe,powershell/wget-ignore-cert.ps1" -vmCreds="$VM_CREDS" $SKIP_VM_SETUP -timeout=30m .
+CGO_ENABLED=0 GO111MODULE=on go test -v -run=TestWMCB \
+-filesToBeTransferred="../../../wmcb_unit_test.exe,../../../wmcb_e2e_test.exe,powershell/wget-ignore-cert.ps1,$HYBRID_OVERLAY_BIN,$KUBELET_BIN" \
+-vmCreds="$VM_CREDS" $SKIP_VM_SETUP -timeout=30m .

--- a/internal/test/framework/framework.go
+++ b/internal/test/framework/framework.go
@@ -173,12 +173,6 @@ func (f *TestFramework) Setup(vmCount int, credentials []*types.Credentials, ski
 	if err := f.getClusterAddress(config); err != nil {
 		return fmt.Errorf("unable to get cluster address: %v", err)
 	}
-	if err := f.getClusterVersion(); err != nil {
-		return fmt.Errorf("unable to get OpenShift cluster version: %v", err)
-	}
-	if err := f.getLatestWMCBRelease(); err != nil {
-		return fmt.Errorf("unable to get latest WMCB release: %v", err)
-	}
 	if err := f.getLatestCniPluginsVersion(); err != nil {
 		return fmt.Errorf("unable to get latest 0.8.x version of CNI Plugins: %v", err)
 	}
@@ -240,10 +234,10 @@ func (f *TestFramework) getClusterAddress(config *restclient.Config) error {
 	return nil
 }
 
-// getClusterVersion gets the OpenShift cluster version in major.minor format. This is being done this way, and not with
+// GetClusterVersion gets the OpenShift cluster version in major.minor format. This is being done this way, and not with
 // oc get clusterversion, as OpenShift CI doesn't have the actual version attached to its clusters, instead replacing it
 // with 0.0.1 and information about the release creation date
-func (f *TestFramework) getClusterVersion() error {
+func (f *TestFramework) GetClusterVersion() error {
 	versionInfo, err := f.OSConfigClient.Discovery().ServerVersion()
 	if err != nil {
 		return fmt.Errorf("error while retrieving k8s version : %v", err)
@@ -305,9 +299,9 @@ func (f *TestFramework) getGithubReleases(owner string, repo string) ([]*github.
 	return releases, err
 }
 
-// getLatestWMCBRelease gets the latest github release for the wmcb repo. This release is specific to the cluster
+// GetLatestWMCBRelease gets the latest github release for the WMCB repo. This release is specific to the cluster
 // version
-func (f *TestFramework) getLatestWMCBRelease() error {
+func (f *TestFramework) GetLatestWMCBRelease() error {
 	releases, err := f.getGithubReleases("openshift", "windows-machine-config-bootstrapper")
 	if err != nil {
 		return err

--- a/internal/test/wmcb/pkginfo.go
+++ b/internal/test/wmcb/pkginfo.go
@@ -54,10 +54,6 @@ func pkgInfoFactory(name pkgName, shaType string, baseUrl string, version string
 	switch name {
 	case cniPluginPkgName:
 		return newCniPluginPkg(name, shaType, baseUrl, version)
-	case hybridOverlayPkgName:
-		return newHybridOverlayPkg(name, shaType)
-	case kubeNodePkgName:
-		return newKubeNodePkg(name, shaType, baseUrl, version)
 
 	default:
 		return nil, fmt.Errorf("invalid Package name")
@@ -77,39 +73,6 @@ func newCniPluginPkg(name pkgName, shaType string, baseUrl string, version strin
 			name:    name,
 			url:     baseUrl + version + "/cni-plugins-windows-amd64-" + version + ".tgz",
 			shaType: shaType,
-		},
-	}, nil
-}
-
-// newHybridOverlayPkg returns hybridOverlay implementation of PkgInfo interface
-func newHybridOverlayPkg(name pkgName, shaType string) (PkgInfo, error) {
-	hybridOverlayUrl, err := framework.GetReleaseArtifactURL(hybridOverlayName)
-	if err != nil {
-		return nil, err
-	}
-	return &hybridOverlay{
-		pkgInfo{
-			name:    name,
-			shaType: shaType,
-			url:     hybridOverlayUrl,
-		},
-	}, nil
-}
-
-// newKubeNodePkg returns kubeNode implementation of PkgInfo interface
-func newKubeNodePkg(name pkgName, shaType string, baseUrl string, version string) (PkgInfo, error) {
-	if version == "" {
-		return nil, fmt.Errorf("k8s version is not specified")
-	}
-	if baseUrl == "" {
-		return nil, fmt.Errorf("base url for kube node binary is not specified")
-	}
-
-	return &kubeNode{
-		pkgInfo{
-			name:    name,
-			shaType: shaType,
-			url:     baseUrl + version + "/kubernetes-node-windows-amd64.tar.gz",
 		},
 	}, nil
 }
@@ -167,35 +130,4 @@ func (p *pkgInfo) getShaType() string {
 //getUrl returns the url of the package
 func (p *pkgInfo) getUrl() string {
 	return p.url
-}
-
-//getShaValue returns the SHA value for the hybrid overlay package
-func (h *hybridOverlay) getShaValue() (string, error) {
-	if h.sha != "" {
-		return h.sha, nil
-	}
-	hybridOverlaySHA, err := framework.GetReleaseArtifactSHA(hybridOverlayName)
-	if err != nil {
-		return "", err
-	}
-	h.sha = hybridOverlaySHA
-	return h.sha, nil
-}
-
-//getShaValue returns the SHA value for the hybrid overlay package
-func (k *kubeNode) getShaValue() (string, error) {
-	if k.sha != "" {
-		return k.sha, nil
-	}
-	checksumFileContent, err := k.getShaFileContent()
-	if err != nil {
-		return "", err
-	}
-	// The checksum file content is in the format "<sha>".
-	sha512 := strings.Split(checksumFileContent, "\n")
-	if len(sha512) < 1 {
-		return "", fmt.Errorf("checksum file content is not in the format : '<sha>'")
-	}
-	k.sha = sha512[0]
-	return k.sha, nil
 }

--- a/internal/test/wsu/wsu_test.go
+++ b/internal/test/wsu/wsu_test.go
@@ -68,6 +68,13 @@ func (f *wsuFramework) Setup(vmCount int, credentials []*types.Credentials, skip
 		fmt.Errorf("framework setup failed: %v", err)
 		return err
 	}
+	if err := f.GetLatestWMCBRelease(); err != nil {
+		return fmt.Errorf("unable to get latest WMCB release: %v", err)
+	}
+
+	if err := f.GetClusterVersion(); err != nil {
+		return fmt.Errorf("unable to get OpenShift cluster version: %v", err)
+	}
 
 	// Set 'buildWMCB' property of Windows VM
 	// Not ideal to set a generic property in a specific implementation. This is a temporary workaround and will be


### PR DESCRIPTION
Remove the dependency on having an hybrid-overlay-node.exe and kubelet.exe being in a GitHub release by:
- Building it the hack script
- Copying the binaries to the Windows VM instead of remote downloading it from the release URL
- Move GetClusterVersion() and GetLatestWMCBRelease() from framework.Setup() into the wsuFramework.Setup()