### PR TITLE
[wmcb] Add 1.3 pause pod image

### DIFF
--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -35,7 +35,7 @@ const (
 	// this is used to parse the kubelet args
 	kubeletSystemdName = "kubelet.service"
 	// kubeletPauseContainerImage is the location of the image we will use for the kubelet pause container
-	kubeletPauseContainerImage = "mcr.microsoft.com/k8s/core/pause:1.2.0"
+	kubeletPauseContainerImage = "mcr.microsoft.com/oss/kubernetes/pause:1.3.0"
 	// serviceWaitTime is an arbitrary amount of time to wait for the Windows service API to complete requests
 	serviceWaitTime = time.Second * 10
 	// certDirectory is where the kubelet will look for certificates


### PR DESCRIPTION
The pause pod image we're using now doesn't include 1909 and 1903 images causing
problems when pod sandbox is getting created for those Windows builds. This
should fix the problem

Ref: https://github.com/kubernetes/kubernetes/issues/87339#issuecomment-582136209