### PR TITLE
WINC-460: Update to Go 1.15

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,26 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal as build
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 as build
 LABEL stage=build
-
-RUN microdnf -y install rsync make git tar findutils diffutils
-
-# We are explictly downloading Go instead of using `microdnf install`, as microdnf currently installs Go v1.13.x,
-# we need minimim Go v1.14.4 for building the kubelet.
-# Download and install Go
-RUN curl -L -s https://dl.google.com/go/go1.14.7.linux-amd64.tar.gz > go1.14.7.linux-amd64.tar.gz \
-    && sha256sum go1.14.7.linux-amd64.tar.gz \
-    && echo "4a7fa60f323ee1416a4b1425aefc37ea359e9d64df19c326a58953a97ad41ea5  go1.14.7.linux-amd64.tar.gz" | sha256sum -c \
-    && tar -xzf go1.14.7.linux-amd64.tar.gz \
-    && mv go /usr/local \
-    && rm -rf ./go*
-
-# Configuring go
-RUN mkdir /go/
-RUN chmod -R g=u+w /go
-ENV GOCACHE="/go/.cache"
-ENV PATH="${PATH}:/usr/local/go/bin"
-ENV GOPATH="/go"
-
-RUN mkdir /build/
 WORKDIR /build/
 
 # Build kubelet.exe
@@ -50,27 +29,8 @@ RUN make build-wmcb-e2e-test
 WORKDIR /build/internal/test/wmcb/
 RUN CGO_ENABLED=0 GO111MODULE=on go test -c -run=TestWMCB -timeout=30m . -o test-wmcb
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal as testing
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 as testing
 LABEL stage=testing
-
-RUN microdnf -y install rsync make git tar findutils diffutils
-
-# We are explictly downloading Go instead of using `microdnf install`, as microdnf currently installs Go v1.13.x,
-# keeping this in sync with build stage.
-# Download and install Go
-RUN curl -L -s https://dl.google.com/go/go1.14.7.linux-amd64.tar.gz > go1.14.7.linux-amd64.tar.gz \
-    && sha256sum go1.14.7.linux-amd64.tar.gz \
-    && echo "4a7fa60f323ee1416a4b1425aefc37ea359e9d64df19c326a58953a97ad41ea5  go1.14.7.linux-amd64.tar.gz" | sha256sum -c \
-    && tar -xzf go1.14.7.linux-amd64.tar.gz \
-    && mv go /usr/local \
-    && rm -rf ./go*
-
-# Configuring go
-RUN mkdir /go/
-RUN chmod -R g=u+w /go
-ENV GOCACHE="/go/.cache"
-ENV PATH="${PATH}:/usr/local/go/bin"
-ENV GOPATH="/go"
 
 WORKDIR /home/test
 COPY internal/test/wmcb/templates templates

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/windows-machine-config-bootstrapper
 
-go 1.14
+go 1.15
 
 // Replace is used to pin a specific version of a package or to point to sub-go.mod directories.
 // Use 'replace' to point to the sub-go.mod directory for building a binary in the root directory and always build by

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -5,7 +5,7 @@ WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.10|go1.11|go1.12|go1.13|go1.14') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.14|go1.15') ]]; then
   echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
   exit 1
 fi

--- a/internal/test/go.mod
+++ b/internal/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/windows-machine-config-bootstrapper/internal/test
 
-go 1.14
+go 1.15
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM


### PR DESCRIPTION
This commit does the following things:
- Updates go.mod file to go 1.15
- Updates hack/verify-gofmt.sh to check for go version 1.15
- Replaces FROM directives in Dockerfile.tools with
registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6