### PR TITLE
[release-4.6] Dockerfile.tools: Clone WMCO repo and build submodules from there

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,9 +1,13 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 as build
 LABEL stage=build
+
+# Clone WMCO repo and initialize submodules for building of windows binaries payload for e2e testing 
 WORKDIR /build/
+RUN git clone --branch release-4.6 --single-branch https://github.com/openshift/windows-machine-config-operator.git
+WORKDIR /build/windows-machine-config-operator/
+RUN git submodule update --init containernetworking-plugins kubernetes ovn-kubernetes
 
-RUN git clone --branch release-4.6 --single-branch --recurse-submodules https://github.com/openshift/windows-machine-config-operator.git
-
+# Build kubelet.exe
 WORKDIR /build/windows-machine-config-operator/kubernetes/
 RUN KUBE_BUILD_PLATFORMS=windows/amd64 make WHAT=cmd/kubelet
 


### PR DESCRIPTION
This ensures the testing in this repository builds and uses the
containernetworking-plugins, kubernetes, and ovn-kubernetes binaries
from the commits pinned in their respective submodules in the WMCO repo.

Backport of https://github.com/openshift/windows-machine-config-bootstrapper/pull/242