### PR TITLE
[community-4.6] Dockerfile.tools: Clone WMCO repo and build submodules from there

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,24 +1,22 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 as build
 LABEL stage=build
+
+# Clone WMCO repo and initialize submodules for building of windows binaries payload for e2e testing 
 WORKDIR /build/
+RUN git clone --branch community-4.6 --single-branch https://github.com/openshift/windows-machine-config-operator.git
+WORKDIR /build/windows-machine-config-operator/
+RUN git submodule update --init containernetworking-plugins kubernetes ovn-kubernetes
 
 # Build kubelet.exe
-RUN git clone --branch release-4.6 https://github.com/openshift/kubernetes.git
-WORKDIR /build/kubernetes/
-# TODO: Checking out commit before go1.15 became a requirement, revert checkout in https://issues.redhat.com/browse/WINC-460
-RUN git checkout f5121a6a6a02ddfafd2bfbf5201b092dc5097ab0
+WORKDIR /build/windows-machine-config-operator/kubernetes/
 RUN KUBE_BUILD_PLATFORMS=windows/amd64 make WHAT=cmd/kubelet
 
 # Build hybrid-overlay-node.exe
-WORKDIR /build/
-RUN git clone --branch release-4.6 --single-branch https://github.com/openshift/ovn-kubernetes.git
-WORKDIR /build/ovn-kubernetes/go-controller/
+WORKDIR /build/windows-machine-config-operator/ovn-kubernetes/go-controller/
 RUN make windows
 
 # Build CNI plugins
-WORKDIR /build/
-RUN git clone --branch release-4.6 --single-branch https://github.com/openshift/containernetworking-plugins
-WORKDIR /build/containernetworking-plugins/
+WORKDIR /build/windows-machine-config-operator/containernetworking-plugins/
 ENV CGO_ENABLED=0
 RUN ./build_windows.sh
 
@@ -37,15 +35,15 @@ FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 
 LABEL stage=testing
 
 WORKDIR /payload/cni
-COPY --from=build /build/containernetworking-plugins/bin/flannel.exe .
-COPY --from=build /build/containernetworking-plugins/bin/host-local.exe .
-COPY --from=build /build/containernetworking-plugins/bin/win-bridge.exe .
-COPY --from=build /build/containernetworking-plugins/bin/win-overlay.exe .
+COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/flannel.exe .
+COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/host-local.exe .
+COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/win-bridge.exe .
+COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/win-overlay.exe .
 
 WORKDIR /payload
 COPY internal/test/wmcb/powershell/ .
-COPY --from=build /build/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe .
-COPY --from=build /build/kubernetes/_output/local/bin/windows/amd64/kubelet.exe .
+COPY --from=build /build/windows-machine-config-operator/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe .
+COPY --from=build /build/windows-machine-config-operator/kubernetes/_output/local/bin/windows/amd64/kubelet.exe .
 COPY --from=build /build/wmcb_unit_test.exe .
 COPY --from=build /build/wmcb_e2e_test.exe .
 


### PR DESCRIPTION
This ensures the testing in this repository builds and uses the
containernetworking-plugins, kubernetes, and ovn-kubernetes binaries
from the commits pinned in their respective submodules in the WMCO repo.

Backport of #242