### PR TITLE
 [ci] Define build_root_image within WMCB repo

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,5 @@
+# Defining this here allows us to atomically change both the code and the go version used to build the code in CI.
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: golang-1.15


### PR DESCRIPTION
This commit allows us to change the build_root_image with commits to
this repo. This is to maintain consistency with the WMCO repo and to
not require explict changes to openshift/release during go version update.