### PR TITLE
Bug 1894649: [community-4.6] Fix Node NotReady state when updating Kubelet service.

### DIFF
--- a/internal/test/wmcb/wmcb_test.go
+++ b/internal/test/wmcb/wmcb_test.go
@@ -412,4 +412,16 @@ func testWMCBCluster(t *testing.T) {
 		metav1.ListOptions{LabelSelector: e2ef.WindowsLabel})
 	require.NoErrorf(t, err, "error while getting Windows node: %v", err)
 	assert.Lenf(t, winNodes.Items, 1, "expected one node to have node label but found: %v", len(winNodes.Items))
+	// Test Windows Nodes for Ready status
+	for _, node := range winNodes.Items {
+		readyCondition := false
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == v1.NodeReady {
+				readyCondition = true
+				assert.Equalf(t, v1.ConditionTrue, condition.Status, "expected Windows node %v should be in %v State",
+					node.Name, condition.Status)
+			}
+		}
+		assert.Truef(t, readyCondition, "expected node Status to have condition type Ready for node %v", node.Name)
+	}
 }


### PR DESCRIPTION
This commmit ensures that we fix the issue created by PR #239
where a Windows Node goes to a NotReady state, when kubelet
is updated. The issue was caused by cloud-provider kubelet arg
getting overrided by empty string. initializeKubeletFiles function
was not being called during update kubelet, since all files are already
present in the VM, however the function was also responsible for setting
cloud-provider arg. To resolve this issue, this commit makes changes
to call the  initializeKubeletFiles function during update. It is
also required to stop an already running kubelet service before
initializeKubeletFiles is called to avoid file access errors. The
commit also adds tests to check for Ready state for Windows Node.

(cherry picked from commit a22ec439c9a447b26f414b7ee11a5ec1b61c4920)