### PR TITLE
Bug 1903330: WMCO successfully reconciles with incorrect configure-cni command

### DIFF
--- a/cmd/bootstrapper/main.go
+++ b/cmd/bootstrapper/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/spf13/cobra"
 	logger "sigs.k8s.io/controller-runtime/pkg/log"
@@ -35,5 +36,6 @@ func init() {
 func main() {
 	if err := rootCmd.Execute(); err != nil {
 		log.Error(err, "wmcb execution failed")
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This change was made to raise WMCB errors as a proper failure
(top-level exit call) instead of just logging them to stderr.