### PR TITLE
WINC-555: [wmcb] Support Windows Server 20H2

### DIFF
--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -42,7 +42,7 @@ const (
 	// this is used to parse the kubelet args
 	kubeletSystemdName = "kubelet.service"
 	// kubeletPauseContainerImage is the location of the image we will use for the kubelet pause container
-	kubeletPauseContainerImage = "mcr.microsoft.com/oss/kubernetes/pause:1.3.0"
+	kubeletPauseContainerImage = "mcr.microsoft.com/oss/kubernetes/pause:3.4.1"
 	// serviceWaitTime is amount of wait time required for the Windows service API to complete stop requests
 	serviceWaitTime = time.Second * 20
 	// certDirectory is where the kubelet will look for certificates


### PR DESCRIPTION
This requires upgrading the pause image to 3.4.1 which has support for Windows Server 20H2.