### PR TITLE
[wmcb] Add uninstall kubelet command line option

### DIFF
--- a/cmd/bootstrapper/uninstall_kubelet.go
+++ b/cmd/bootstrapper/uninstall_kubelet.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/windows-machine-config-bootstrapper/pkg/bootstrapper"
+)
+
+var (
+	// uninstallKubeletCmd describes the uninstall-kubelet command
+	uninstallKubeletCmd = &cobra.Command{
+		Use:   "uninstall-kubelet",
+		Short: "Stops and removes the kubelet service",
+		Long:  "Stops and removes the kubelet service",
+		Run:   runUninstallKubeletCmd,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(uninstallKubeletCmd)
+}
+
+// runUninstallKubeletCmd uninstalls kubelet service from the Windows node
+func runUninstallKubeletCmd(cmd *cobra.Command, args []string) {
+	flag.Parse()
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "")
+	if err != nil {
+		log.Error(err, "could not create bootstrapper")
+		os.Exit(1)
+	}
+
+	// uninstall kubelet Windows service
+	if err = wmcb.UninstallKubelet(); err != nil {
+		log.Error(err, "could not uninstall kubelet")
+		os.Exit(1)
+	}
+
+	// Send success message to StdOut to ascertain that kubelet removal was successful
+	os.Stdout.WriteString("kubelet uninstalled successfully")
+
+	if err = wmcb.Disconnect(); err != nil {
+		log.Error(err, "can't clean up bootstrapper")
+	}
+}

--- a/internal/test/wmcb/wmcb_test.go
+++ b/internal/test/wmcb/wmcb_test.go
@@ -109,6 +109,9 @@ func (vm *wmcbVM) runE2ETestSuite(t *testing.T) {
 	vm.runTestBootstrapper(t)
 
 	vm.runTestConfigureCNI(t)
+
+	// Run this test only after TestBoostrapper() to ensure kubelet service is present.
+	vm.runTestKubeletUninstall(t)
 }
 
 // runTest runs the testCmd in the given VM
@@ -285,6 +288,11 @@ func (vm *wmcbVM) waitForHybridOverlayToRun() error {
 
 	// hybrid-overlay-node never started running
 	return fmt.Errorf("timeout waiting for hybrid-overlay-node: %v", err)
+}
+
+func (vm *wmcbVM) runTestKubeletUninstall(t *testing.T) {
+	err := vm.runTest(e2eExecutable + " --test.run TestKubeletUninstall --test.v")
+	require.NoError(t, err, "TestKubeletUninstall failed")
 }
 
 // mkdirCmd returns the Windows command to create a directory if it does not exists

--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -149,7 +149,7 @@ type cniOptions struct {
 
 // NewWinNodeBootstrapper takes the dir to install the kubelet to, and paths to the ignition and kubelet files along
 // with the CNI options as inputs, and generates the winNodeBootstrapper object. The CNI options are populated only in
-// the configure-cni command.
+// the configure-cni command. The inputs to NewWinNodeBootstrapper are ignored while using the uninstall kubelet functionality.
 func NewWinNodeBootstrapper(k8sInstallDir, ignitionFile, kubeletPath string, cniDir string,
 	cniConfig string) (*winNodeBootstrapper, error) {
 	// Check if cniDir or cniConfig is empty when the other is not
@@ -665,6 +665,19 @@ func (wmcb *winNodeBootstrapper) Disconnect() error {
 	err := wmcb.svcMgr.Disconnect()
 	wmcb.svcMgr = nil
 	return err
+}
+
+// UninstallKubelet uninstalls the kubelet service from Windows node
+func (wmcb *winNodeBootstrapper) UninstallKubelet() error {
+	if wmcb.kubeletSVC == nil {
+		return fmt.Errorf("kubelet service is not present")
+	}
+	// Stop and remove kubelet service if it is in Running state.
+	err := wmcb.kubeletSVC.stopAndRemove()
+	if err != nil {
+		return fmt.Errorf("failed to stop and remove kubelet service: %v", err)
+	}
+	return nil
 }
 
 func copyFile(src, dest string) error {

--- a/pkg/bootstrapper/kubelet.go
+++ b/pkg/bootstrapper/kubelet.go
@@ -183,6 +183,17 @@ func (k *kubeletService) setRecoveryActions() error {
 	return nil
 }
 
+// stopAndRemove stops and removes the kubelet service
+func (k *kubeletService) stopAndRemove() error {
+	if k.obj == nil {
+		return nil
+	}
+	if err := k.stop(); err != nil {
+		return fmt.Errorf("failed to stop kubelet service: %v", err)
+	}
+	return k.obj.Delete()
+}
+
 // startService is a helper to start a given service
 func startService(serviceObj *mgr.Service) error {
 	if serviceObj == nil {

--- a/test/e2e/bootstrapper_test.go
+++ b/test/e2e/bootstrapper_test.go
@@ -59,6 +59,8 @@ func TestBootstrapper(t *testing.T) {
 
 	t.Run("Configure CNI without kubelet service present", testConfigureCNIWithoutKubeletSvc)
 
+	t.Run("Uninstall kubelet without kubelet service present", testUninstallWithoutKubeletSvc)
+
 	// Run the bootstrapper, which will start the kubelet service
 	wmcb, err := bootstrapper.NewWinNodeBootstrapper(installDir, ignitionFilePath, kubeletPath, "", "")
 	require.NoErrorf(t, err, "Could not create WinNodeBootstrapper: %s", err)

--- a/test/e2e/uninstall_kubelet_test.go
+++ b/test/e2e/uninstall_kubelet_test.go
@@ -1,0 +1,38 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openshift/windows-machine-config-bootstrapper/pkg/bootstrapper"
+)
+
+// TestKubeletUninstall tests if WMCB returns an error if the kubelet is uninstalled
+func TestKubeletUninstall(t *testing.T) {
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "")
+	require.NoError(t, err, "could not create wmcb")
+
+	err = wmcb.UninstallKubelet()
+	assert.NoError(t, err, "unable to uninstall kubelet service")
+
+	err = wmcb.Disconnect()
+	assert.NoError(t, err, "could not disconnect from windows svc API")
+
+	assert.False(t, svcExists(t, bootstrapper.KubeletServiceName))
+}
+
+// testUninstallWithoutKubeletSvc tests if WMCB returns an error if the kubelet is uninstalled with no kubelet service present
+func testUninstallWithoutKubeletSvc(t *testing.T) {
+	if svcExists(t, bootstrapper.KubeletServiceName) {
+		t.Skip("Skipping as kubelet service already exists")
+	}
+
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "")
+	require.NoError(t, err, "could not create wmcb")
+
+	err = wmcb.UninstallKubelet()
+	assert.Error(t, err, "no error when attempting to uninstall kubelet without kubelet svc")
+	assert.Contains(t, err.Error(), "kubelet service is not present", "incorrect error thrown")
+}


### PR DESCRIPTION
This PR  adds a command line option "uninstall-kubelet " to uninstall the existing kubelet service from the Windows node. This will help in BYOH implementation to uninstall all services.