### PR TITLE
Reflect WMCO kubelet submodule change

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -5,10 +5,10 @@ LABEL stage=build
 WORKDIR /build/
 RUN git clone --branch release-4.8 --single-branch https://github.com/openshift/windows-machine-config-operator.git
 WORKDIR /build/windows-machine-config-operator/
-RUN git submodule update --init containernetworking-plugins kubernetes ovn-kubernetes
+RUN git submodule update --init containernetworking-plugins kubelet ovn-kubernetes
 
 # Build kubelet.exe
-WORKDIR /build/windows-machine-config-operator/kubernetes/
+WORKDIR /build/windows-machine-config-operator/kubelet/
 RUN KUBE_BUILD_PLATFORMS=windows/amd64 make WHAT=cmd/kubelet
 
 # Build hybrid-overlay-node.exe
@@ -43,7 +43,7 @@ COPY --from=build /build/windows-machine-config-operator/containernetworking-plu
 WORKDIR /payload
 COPY internal/test/wmcb/powershell/ .
 COPY --from=build /build/windows-machine-config-operator/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe .
-COPY --from=build /build/windows-machine-config-operator/kubernetes/_output/local/bin/windows/amd64/kubelet.exe .
+COPY --from=build /build/windows-machine-config-operator/kubelet/_output/local/bin/windows/amd64/kubelet.exe .
 COPY --from=build /build/wmcb_unit_test.exe .
 COPY --from=build /build/wmcb_e2e_test.exe .
 

--- a/test/e2e/configure_cni_test.go
+++ b/test/e2e/configure_cni_test.go
@@ -92,5 +92,5 @@ func isCNIConfigured(t *testing.T, logPath string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return strings.Contains(string(buf), "Loaded network plugin \"cni\""), nil
+	return strings.Contains(string(buf), "\"Loaded network plugin\" networkPluginName=\"cni\""), nil
 }


### PR DESCRIPTION
https://github.com/openshift/windows-machine-config-operator/pull/395 renamed the kubernetes submodule to kubelet. Reflect that here and update the CNI configuration check 