### PR TITLE
[test] Fix error output not being shown in logs

### DIFF
--- a/internal/test/windows/windows.go
+++ b/internal/test/windows/windows.go
@@ -142,7 +142,7 @@ func (w *Windows) Run(cmd string, psCmd bool) (string, error) {
 
 	out, err := session.CombinedOutput(cmd)
 	if err != nil {
-		return "", err
+		return string(out), err
 	}
 	return string(out), nil
 }


### PR DESCRIPTION
Fix the Run() method which was not returning the output when the command returned an error.