### PR TITLE
[OCPCLOUD-1247] Allow to override kubelet hostname

### DIFF
--- a/cmd/bootstrapper/configure_cni.go
+++ b/cmd/bootstrapper/configure_cni.go
@@ -55,7 +55,7 @@ func runConfigureCNICmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	wmcb, err := bootstrapper.NewWinNodeBootstrapper(configureCNIOpts.installDir, "", "", "", "", configureCNIOpts.dir,
-		configureCNIOpts.config)
+		configureCNIOpts.config, "")
 	if err != nil {
 		log.Error(err, "could not create bootstrapper")
 		os.Exit(1)

--- a/cmd/bootstrapper/initialize_kubelet.go
+++ b/cmd/bootstrapper/initialize_kubelet.go
@@ -39,6 +39,8 @@ var (
 		nodeIP string
 		// clusterDNS is the IP address of the DNS server used for all containers
 		clusterDNS string
+		// hostname contains the name of the host
+		hostname string
 	}
 )
 
@@ -56,6 +58,8 @@ func init() {
 	initializeKubeletCmd.PersistentFlags().StringVar(&initializeKubeletOpts.clusterDNS, "cluster-dns", "",
 		"The DNS server IP passed to kubelet, that will be used to configure all containers for DNS resolution. "+
 			"If unset, kubelet will determine the DNS server to use.")
+	initializeKubeletCmd.PersistentFlags().StringVar(&initializeKubeletOpts.hostname, "hostname", "",
+		"hostname defines custom name of the host.")
 }
 
 // runInitializeKubeletCmd starts the Windows Machine Config Bootstrapper
@@ -65,7 +69,7 @@ func runInitializeKubeletCmd(cmd *cobra.Command, args []string) {
 
 	wmcb, err := bootstrapper.NewWinNodeBootstrapper(initializeKubeletOpts.installDir,
 		initializeKubeletOpts.ignitionFile, initializeKubeletOpts.kubeletPath,
-		initializeKubeletOpts.nodeIP, initializeKubeletOpts.clusterDNS, "", "")
+		initializeKubeletOpts.nodeIP, initializeKubeletOpts.clusterDNS, "", "", initializeKubeletOpts.hostname)
 	if err != nil {
 		log.Error(err, "could not create bootstrapper")
 		os.Exit(1)

--- a/cmd/bootstrapper/uninstall_kubelet.go
+++ b/cmd/bootstrapper/uninstall_kubelet.go
@@ -26,7 +26,7 @@ func init() {
 // runUninstallKubeletCmd uninstalls kubelet service from the Windows node
 func runUninstallKubeletCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "", "", "")
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "", "", "", "")
 	if err != nil {
 		log.Error(err, "could not create bootstrapper")
 		os.Exit(1)

--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -140,6 +140,8 @@ type winNodeBootstrapper struct {
 	kubeletArgs []string
 	// cni holds all the CNI specific information
 	cni *cniOptions
+	// hostname contains the name for the host
+	hostname string
 }
 
 // cniOptions is responsible for reconfiguring the kubelet service with CNI configuration
@@ -161,7 +163,7 @@ type cniOptions struct {
 // object. The CNI options are populated only in the configure-cni command. The inputs to NewWinNodeBootstrapper are
 // ignored while using the uninstall kubelet functionality.
 func NewWinNodeBootstrapper(k8sInstallDir, ignitionFile, kubeletPath, nodeIP, clusterDNS, cniDir,
-	cniConfig string) (*winNodeBootstrapper, error) {
+	cniConfig string, hostname string) (*winNodeBootstrapper, error) {
 	// Check if cniDir or cniConfig is empty when the other is not
 	if (cniDir == "" && cniConfig != "") || (cniDir != "" && cniConfig == "") {
 		return nil, fmt.Errorf("both cniDir and cniConfig need to be populated")
@@ -195,6 +197,7 @@ func NewWinNodeBootstrapper(k8sInstallDir, ignitionFile, kubeletPath, nodeIP, cl
 		svcMgr:             svcMgr,
 		nodeIP:             nodeIP,
 		clusterDNS:         clusterDNS,
+		hostname:           hostname,
 	}
 	// populate the CNI struct if CNI options are present
 	if cniDir != "" && cniConfig != "" {
@@ -557,6 +560,9 @@ func (wmcb *winNodeBootstrapper) generateInitialKubeletArgs(args map[string]stri
 	}
 	if wmcb.nodeIP != "" {
 		kubeletArgs = append(kubeletArgs, "--node-ip="+wmcb.nodeIP)
+	}
+	if wmcb.hostname != "" {
+		kubeletArgs = append(kubeletArgs, "--hostname-override="+wmcb.hostname)
 	}
 	return kubeletArgs
 }

--- a/pkg/bootstrapper/bootstrapper_test.go
+++ b/pkg/bootstrapper/bootstrapper_test.go
@@ -428,11 +428,11 @@ func TestCloudConfInvalidNames(t *testing.T) {
 // TestNewWinNodeBootstrapperWithInvalidCNIInputs tests if NewWinNodeBootstrapper returns the expected error on passing
 // invalid CNI inputs
 func TestNewWinNodeBootstrapperWithInvalidCNIInputs(t *testing.T) {
-	_, err := NewWinNodeBootstrapper("", "", "", "", "", "C:\\something", "")
+	_, err := NewWinNodeBootstrapper("", "", "", "", "", "C:\\something", "", "")
 	require.Error(t, err, "no error thrown when cniDir is not empty and cniConfig is empty")
 	assert.Contains(t, err.Error(), "both cniDir and cniConfig need to be populated", "incorrect error thrown")
 
-	_, err = NewWinNodeBootstrapper("", "", "", "", "", "", "C:\\something")
+	_, err = NewWinNodeBootstrapper("", "", "", "", "", "", "C:\\something", "")
 	require.Error(t, err, "no error thrown when cniDir is empty and cniConfig not empty")
 	assert.Contains(t, err.Error(), "both cniDir and cniConfig need to be populated", "incorrect error thrown")
 }
@@ -440,7 +440,7 @@ func TestNewWinNodeBootstrapperWithInvalidCNIInputs(t *testing.T) {
 // TestWinNodeBootstrapperConfigureWithInvalidInputs tests if Configure returns the expected error when CNI inputs
 // are not present
 func TestWinNodeBootstrapperConfigureWithInvalidInputs(t *testing.T) {
-	wnb, err := NewWinNodeBootstrapper("", "", "", "", "", "", "")
+	wnb, err := NewWinNodeBootstrapper("", "", "", "", "", "", "", "")
 	require.NoError(t, err, "error instantiating bootstrapper")
 	err = wnb.Configure()
 	require.Error(t, err, "no error thrown when Configure is called with no CNI inputs")

--- a/test/e2e/bootstrapper_test.go
+++ b/test/e2e/bootstrapper_test.go
@@ -62,7 +62,7 @@ func TestBootstrapper(t *testing.T) {
 	t.Run("Uninstall kubelet without kubelet service present", testUninstallWithoutKubeletSvc)
 
 	// Run the bootstrapper, which will start the kubelet service
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper(installDir, ignitionFilePath, kubeletPath, "", "", "", "")
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper(installDir, ignitionFilePath, kubeletPath, "", "", "", "", "my-computer")
 	require.NoErrorf(t, err, "Could not create WinNodeBootstrapper: %s", err)
 	err = wmcb.InitializeKubelet()
 	assert.NoErrorf(t, err, "Could not run bootstrapper: %s", err)
@@ -108,6 +108,9 @@ func TestBootstrapper(t *testing.T) {
 	})
 	t.Run("Test the config dependencies in Kubelet arguments", func(t *testing.T) {
 		assert.ElementsMatch(t, expectedDependencies, actualDependencies)
+	})
+	t.Run("Test hostname", func(t *testing.T) {
+		testHostname(t, path)
 	})
 }
 
@@ -207,6 +210,22 @@ func testPathInKubeletArgs(t *testing.T, checkPathsFor []string, path string) {
 				if key == argSplit[0] {
 					assert.Containsf(t, argSplit[1], string(os.PathSeparator), "Path not correctly set for %s", key)
 				}
+			}
+		}
+	}
+}
+
+// testHostname checks if the hostname given as the argument to kubelet service is correct
+func testHostname(t *testing.T, path string) {
+	// Split the arguments from kubelet path
+	kubeletArg := strings.Split(path, " ")
+	for _, arg := range kubeletArg {
+		// Split the key and value of arg
+		argSplit := strings.SplitN(arg, "=", 2)
+		// Ignore single valued arguments
+		if len(argSplit) > 1 {
+			if argSplit[0] == "--hostname-override" {
+				assert.Equal(t, argSplit[1], "my-computer")
 			}
 		}
 	}

--- a/test/e2e/configure_cni_test.go
+++ b/test/e2e/configure_cni_test.go
@@ -42,7 +42,7 @@ func testConfigureCNIWithoutKubeletSvc(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Instantiate the bootstrapper
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper(tempDir, "", "", "", "", tempDir, cniConfig.Name())
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper(tempDir, "", "", "", "", tempDir, cniConfig.Name(), "")
 	require.NoError(t, err, "could not instantiate wmcb")
 
 	err = wmcb.Configure()
@@ -53,7 +53,7 @@ func testConfigureCNIWithoutKubeletSvc(t *testing.T) {
 // testConfigureCNI tests if ConfigureCNI() runs successfully by checking if the kubelet service comes up after
 // configuring CNI
 func testConfigureCNI(t *testing.T) {
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper(installDir, "", "", "", "", cniDir, cniConfig)
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper(installDir, "", "", "", "", cniDir, cniConfig, "")
 	require.NoError(t, err, "could not create wmcb")
 
 	err = wmcb.Configure()

--- a/test/e2e/uninstall_kubelet_test.go
+++ b/test/e2e/uninstall_kubelet_test.go
@@ -11,7 +11,7 @@ import (
 
 // TestKubeletUninstall tests if WMCB returns an error if the kubelet is uninstalled
 func TestKubeletUninstall(t *testing.T) {
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "", "", "")
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "", "", "", "")
 	require.NoError(t, err, "could not create wmcb")
 
 	err = wmcb.UninstallKubelet()
@@ -29,7 +29,7 @@ func testUninstallWithoutKubeletSvc(t *testing.T) {
 		t.Skip("Skipping as kubelet service already exists")
 	}
 
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "", "", "")
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "", "", "", "")
 	require.NoError(t, err, "could not create wmcb")
 
 	err = wmcb.UninstallKubelet()


### PR DESCRIPTION
This commit adds a new parameter for the bootstrapper: `--hostname`. It allows to define custom hostname for kubelet on the node.

It is required for deploying clusters on Windows machines with Cloud Controller Manager support, where hostnames must be the same as node names.

Related links:
https://issues.redhat.com/browse/OCPCLOUD-1247
https://bugzilla.redhat.com/show_bug.cgi?id=1995894