### PR TITLE
Use images from registry.ci.openshift.org

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM docker.io/openshift/origin-release:golang-1.16 as build
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 as build
 LABEL stage=build
 
 # Clone WMCO repo and initialize submodules for building of windows binaries payload for e2e testing 
@@ -31,7 +31,7 @@ RUN make build-wmcb-e2e-test
 WORKDIR /build/internal/test/wmcb/
 RUN CGO_ENABLED=0 GO111MODULE=on go test -c -run=TestWMCB -timeout=30m . -o test-wmcb
 
-FROM docker.io/openshift/origin-release:golang-1.16 as testing
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 as testing
 LABEL stage=testing
 
 WORKDIR /payload/cni


### PR DESCRIPTION
Now for testing we fetch images from docker hub. Unfortunately, due to recent service policy changes, we can reach daily quota limits. After that CI fails with the error:

> toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading:
> https://www.docker.com/increase-rate-limit

It's better to use our own image registry to prevent such errors.