### PR TITLE
WINC-724: Add OpenShift managed to Kubelet SVC description

### DIFF
--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -95,6 +95,9 @@ const (
 	cniBinDirOption = "--cni-bin-dir"
 	// cniConfDirOption is to specify the CNI conf directory
 	cniConfDirOption = "--cni-conf-dir"
+	// managedServicePrefix indicates that the service being described is managed by OpenShift. This ensures that all
+	// services created as part of Node configuration can be searched for by checking their description for this string
+	managedServicePrefix = "OpenShift managed"
 )
 
 // These regex are global, so that we only need to compile them once
@@ -594,7 +597,7 @@ func (wmcb *winNodeBootstrapper) ensureKubeletService() error {
 		ServiceStartName: "",
 		DisplayName:      "",
 		Password:         "",
-		Description:      "OpenShift Kubelet",
+		Description:      fmt.Sprintf("%s kubelet", managedServicePrefix),
 	}
 
 	if wmcb.kubeletSVC == nil {

--- a/test/e2e/bootstrapper_test.go
+++ b/test/e2e/bootstrapper_test.go
@@ -111,6 +111,11 @@ func TestBootstrapper(t *testing.T) {
 	t.Run("Test the config dependencies in Kubelet arguments", func(t *testing.T) {
 		assert.ElementsMatch(t, expectedDependencies, actualDependencies)
 	})
+	t.Run("Kubelet service has 'OpenShift managed' in description", func(t *testing.T) {
+		config, err := getSvcConfig(bootstrapper.KubeletServiceName)
+		require.NoError(t, err, "error getting Kubelet Config")
+		assert.Contains(t, config.Description, "OpenShift managed")
+	})
 }
 
 // ensureIgnitionFileExists will create a generic ignition file if one is not provided on the node
@@ -178,6 +183,23 @@ func getSvcInfo(svcName string) (svc.State, string, []string, error) {
 	} else {
 		return status.State, "", nil, fmt.Errorf("could not fetch %s path: %s", svcName, err)
 	}
+}
+
+// getSvcConfig returns the configuration of the Windows Service with the given name
+func getSvcConfig(svcName string) (mgr.Config, error) {
+	svcMgr, err := mgr.Connect()
+	if err != nil {
+		return mgr.Config{}, fmt.Errorf("could not connect to Windows SCM: %s", err)
+	}
+	defer svcMgr.Disconnect()
+
+	svcHandle, err := svcMgr.OpenService(svcName)
+	if err != nil {
+		return mgr.Config{}, err
+	}
+	defer svcHandle.Close()
+
+	return svcHandle.Config()
 }
 
 // removeFileIfExists removes the file given by 'path', and will not throw an error if it does not exist


### PR DESCRIPTION
The "openshift-managed" string must be added to the description of all
Windows services created as part of the Windows Node configuration
process. This is a requirement of properly upgrading Nodes. During the
upgrade process, a search can be done for all Windows services with the
string in their description, in order to identify and potentially remove
Services created by us.