### PR TITLE
WINC-602: [wmcb] Support Windows Server 2022

### DIFF
--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -46,7 +46,7 @@ const (
 	// this is used to parse the kubelet args
 	kubeletSystemdName = "kubelet.service"
 	// kubeletPauseContainerImage is the location of the image we will use for the kubelet pause container
-	kubeletPauseContainerImage = "mcr.microsoft.com/oss/kubernetes/pause:3.4.1"
+	kubeletPauseContainerImage = "mcr.microsoft.com/oss/kubernetes/pause:3.6"
 	// serviceWaitTime is amount of wait time required for the Windows service API to complete stop requests
 	serviceWaitTime = time.Second * 20
 	// certDirectory is where the kubelet will look for certificates

--- a/pkg/bootstrapper/bootstrapper_test.go
+++ b/pkg/bootstrapper/bootstrapper_test.go
@@ -264,7 +264,7 @@ func TestKubeletArgs(t *testing.T) {
 	baseExpectedArgs := []string{"--config=\\fakepath\\kubelet.conf",
 		"--bootstrap-kubeconfig=" + filepath.Join(dir, "bootstrap-kubeconfig"),
 		"--kubeconfig=\\fakepath\\kubeconfig",
-		"--pod-infra-container-image=mcr.microsoft.com/oss/kubernetes/pause:3.4.1",
+		"--pod-infra-container-image=mcr.microsoft.com/oss/kubernetes/pause:3.6",
 		"--cert-dir=c:\\var\\lib\\kubelet\\pki\\",
 		"--windows-service",
 		"--logtostderr=false",


### PR DESCRIPTION
This requires upgrading the [pause image to 3.6](https://github.com/kubernetes/kubernetes/blob/master/build/pause/CHANGELOG.md#36)
which has support for Windows Server 2022.