### PR TITLE
WINC-696: Introduce dockerRuntime flag option to update kubelet arguments 

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -8,7 +8,7 @@ RUN yum install -y dos2unix
 WORKDIR /build/
 RUN git clone --branch release-4.11 --single-branch https://github.com/openshift/windows-machine-config-operator.git
 WORKDIR /build/windows-machine-config-operator/
-RUN git submodule update --init containernetworking-plugins kubelet ovn-kubernetes
+RUN git submodule update --init containernetworking-plugins kubelet ovn-kubernetes containerd hcsshim
 
 # Build kubelet.exe
 WORKDIR /build/windows-machine-config-operator/kubelet/
@@ -22,6 +22,14 @@ RUN make windows
 WORKDIR /build/windows-machine-config-operator/containernetworking-plugins/
 ENV CGO_ENABLED=0
 RUN ./build_windows.sh
+
+# Build containerd.exe
+WORKDIR /build/windows-machine-config-operator/containerd/
+RUN GOOS=windows make
+
+# Build containerd shim
+WORKDIR /build/windows-machine-config-operator/hcsshim
+RUN GOOS=windows go build ./cmd/containerd-shim-runhcs-v1
 
 WORKDIR /build/
 COPY . .
@@ -48,6 +56,11 @@ COPY --from=build /build/windows-machine-config-operator/ovn-kubernetes/go-contr
 COPY --from=build /build/windows-machine-config-operator/kubelet/_output/local/bin/windows/amd64/kubelet.exe .
 COPY --from=build /build/wmcb_unit_test.exe .
 COPY --from=build /build/wmcb_e2e_test.exe .
+
+WORKDIR /payload/containerd
+COPY --from=build /build/windows-machine-config-operator/containerd/bin/containerd.exe .
+COPY --from=build /build/windows-machine-config-operator/hcsshim/containerd-shim-runhcs-v1.exe .
+COPY pkg/internal/containerd_conf.toml .
 
 WORKDIR /test
 COPY internal/test/wmcb/templates templates

--- a/cmd/bootstrapper/configure_cni.go
+++ b/cmd/bootstrapper/configure_cni.go
@@ -55,7 +55,7 @@ func runConfigureCNICmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	wmcb, err := bootstrapper.NewWinNodeBootstrapper(configureCNIOpts.installDir, "", "", "", "", configureCNIOpts.dir,
-		configureCNIOpts.config, "")
+		configureCNIOpts.config, "", true)
 	if err != nil {
 		log.Error(err, "could not create bootstrapper")
 		os.Exit(1)

--- a/cmd/bootstrapper/initialize_kubelet.go
+++ b/cmd/bootstrapper/initialize_kubelet.go
@@ -41,6 +41,9 @@ var (
 		clusterDNS string
 		// platformType contains type of the platform where the cluster is deployed
 		platformType string
+		// dockerRuntime set to true indicates the container runtime to be used is docker.
+		// If set to false containerd will be the container runtime.
+		dockerRuntime bool
 	}
 )
 
@@ -60,6 +63,8 @@ func init() {
 			"If unset, kubelet will determine the DNS server to use.")
 	initializeKubeletCmd.PersistentFlags().StringVar(&initializeKubeletOpts.platformType, "platform-type", "",
 		"Type of the platform where the cluster is deployed. Example: AWS, Azure, GCP")
+	initializeKubeletCmd.PersistentFlags().BoolVar(&initializeKubeletOpts.dockerRuntime, "dockerRuntime", true,
+		"Use docker as container runtime. If unset, defaults to true. If false, containerd will be used as the container runtime.")
 }
 
 // runInitializeKubeletCmd starts the Windows Machine Config Bootstrapper
@@ -70,7 +75,7 @@ func runInitializeKubeletCmd(cmd *cobra.Command, args []string) {
 	wmcb, err := bootstrapper.NewWinNodeBootstrapper(initializeKubeletOpts.installDir,
 		initializeKubeletOpts.ignitionFile, initializeKubeletOpts.kubeletPath,
 		initializeKubeletOpts.nodeIP, initializeKubeletOpts.clusterDNS, "", "",
-		initializeKubeletOpts.platformType)
+		initializeKubeletOpts.platformType, initializeKubeletOpts.dockerRuntime)
 	if err != nil {
 		log.Error(err, "could not create bootstrapper")
 		os.Exit(1)

--- a/cmd/bootstrapper/uninstall_kubelet.go
+++ b/cmd/bootstrapper/uninstall_kubelet.go
@@ -26,7 +26,8 @@ func init() {
 // runUninstallKubeletCmd uninstalls kubelet service from the Windows node
 func runUninstallKubeletCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "", "", "", "")
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "",
+		"", "", "", true)
 	if err != nil {
 		log.Error(err, "could not create bootstrapper")
 		os.Exit(1)

--- a/hack/run-wmcb-ci-e2e-test.sh
+++ b/hack/run-wmcb-ci-e2e-test.sh
@@ -57,6 +57,11 @@ fi
 sed -i "s~ARTIFACT_DIR_VALUE~${ARTIFACT_DIR}~g" internal/test/wmcb/deploy/job.yaml
 sed -i "s~REPLACE_IMAGE~${WMCB_IMAGE}~g" internal/test/wmcb/deploy/job.yaml
 
+# If DOCKER_RUNTIME is set, set that value for flag -dockerRuntime in job.yaml.
+# If it is unset, default value taken will be true.
+DOCKER_RUNTIME=${DOCKER_RUNTIME:-true}
+sed -i "s~DOCKER_RUNTIME~${DOCKER_RUNTIME}~g" internal/test/wmcb/deploy/job.yaml
+
 # deploy the test pod on test cluster
 if ! $OC apply -f internal/test/wmcb/deploy/job.yaml -n default; then
     echo "job already deployed"

--- a/internal/test/wmcb/deploy/job.yaml
+++ b/internal/test/wmcb/deploy/job.yaml
@@ -26,6 +26,7 @@ spec:
           args:
             - -test.run=TestWMCB
             - -test.v
+            - -dockerRuntime=DOCKER_RUNTIME
           volumeMounts:
           - name: cloud-private-key
             mountPath: "/etc/private-key/"

--- a/internal/test/wmcb/main_test.go
+++ b/internal/test/wmcb/main_test.go
@@ -13,13 +13,16 @@ var (
 	framework = wmcbFramework{}
 	// TODO: expose this to the end user as a command line flag
 	// vmCount is the number of VMs the test suite requires
-	vmCount = 1
+	vmCount       = 1
+	dockerRuntime bool
 )
 
 func TestMain(m *testing.M) {
 	var skipVMSetup bool
 
 	flag.BoolVar(&skipVMSetup, "skipVMSetup", false, "Option to disable setup in the VMs")
+	flag.BoolVar(&dockerRuntime, "dockerRuntime", true, "Container runtime to be used is docker")
+
 	flag.Parse()
 
 	err := framework.Setup(vmCount, skipVMSetup)

--- a/pkg/bootstrapper/bootstrapper_test.go
+++ b/pkg/bootstrapper/bootstrapper_test.go
@@ -287,6 +287,7 @@ func TestKubeletArgs(t *testing.T) {
 				kubeconfigPath:  filepath.Join("/fakepath/kubeconfig"),
 				kubeletConfPath: filepath.Join("/fakepath/kubelet.conf"),
 				logDir:          "/fakepath/",
+				dockerRuntime:   true,
 			},
 		},
 		{
@@ -298,6 +299,19 @@ func TestKubeletArgs(t *testing.T) {
 				kubeletConfPath: filepath.Join("/fakepath/kubelet.conf"),
 				logDir:          "/fakepath/",
 				nodeIP:          "192.168.1.1",
+				dockerRuntime:   true,
+			},
+		},
+		{
+			name: "With docker runtime set to false",
+			additionalExpectedArgs: []string{"--container-runtime=remote",
+				"--container-runtime-endpoint=npipe://./pipe/containerd-containerd"},
+			wnb: winNodeBootstrapper{
+				installDir:      dir,
+				kubeconfigPath:  filepath.Join("/fakepath/kubeconfig"),
+				kubeletConfPath: filepath.Join("/fakepath/kubelet.conf"),
+				logDir:          "/fakepath/",
+				dockerRuntime:   false,
 			},
 		},
 	}

--- a/pkg/bootstrapper/bootstrapper_test.go
+++ b/pkg/bootstrapper/bootstrapper_test.go
@@ -428,11 +428,11 @@ func TestCloudConfInvalidNames(t *testing.T) {
 // TestNewWinNodeBootstrapperWithInvalidCNIInputs tests if NewWinNodeBootstrapper returns the expected error on passing
 // invalid CNI inputs
 func TestNewWinNodeBootstrapperWithInvalidCNIInputs(t *testing.T) {
-	_, err := NewWinNodeBootstrapper("", "", "", "", "", "C:\\something", "", "")
+	_, err := NewWinNodeBootstrapper("", "", "", "", "", "C:\\something", "", "", true)
 	require.Error(t, err, "no error thrown when cniDir is not empty and cniConfig is empty")
 	assert.Contains(t, err.Error(), "both cniDir and cniConfig need to be populated", "incorrect error thrown")
 
-	_, err = NewWinNodeBootstrapper("", "", "", "", "", "", "C:\\something", "")
+	_, err = NewWinNodeBootstrapper("", "", "", "", "", "", "C:\\something", "", true)
 	require.Error(t, err, "no error thrown when cniDir is empty and cniConfig not empty")
 	assert.Contains(t, err.Error(), "both cniDir and cniConfig need to be populated", "incorrect error thrown")
 }
@@ -440,7 +440,7 @@ func TestNewWinNodeBootstrapperWithInvalidCNIInputs(t *testing.T) {
 // TestWinNodeBootstrapperConfigureWithInvalidInputs tests if Configure returns the expected error when CNI inputs
 // are not present
 func TestWinNodeBootstrapperConfigureWithInvalidInputs(t *testing.T) {
-	wnb, err := NewWinNodeBootstrapper("", "", "", "", "", "", "", "")
+	wnb, err := NewWinNodeBootstrapper("", "", "", "", "", "", "", "", true)
 	require.NoError(t, err, "error instantiating bootstrapper")
 	err = wnb.Configure()
 	require.Error(t, err, "no error thrown when Configure is called with no CNI inputs")

--- a/pkg/internal/containerd_conf.toml
+++ b/pkg/internal/containerd_conf.toml
@@ -1,0 +1,174 @@
+disabled_plugins = []
+imports = []
+oom_score = 0
+plugin_dir = ""
+required_plugins = []
+root = "C:\\ProgramData\\containerd\\root"
+state = "C:\\ProgramData\\containerd\\state"
+version = 2
+
+[cgroup]
+  path = ""
+
+[debug]
+  address = ""
+  format = ""
+  gid = 0
+  level = ""
+  uid = 0
+
+[grpc]
+  address = "\\\\.\\pipe\\containerd-containerd"
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+  tcp_address = ""
+  tcp_tls_cert = ""
+  tcp_tls_key = ""
+  uid = 0
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[plugins]
+
+  [plugins."io.containerd.gc.v1.scheduler"]
+    deletion_threshold = 0
+    mutation_threshold = 100
+    pause_threshold = 0.02
+    schedule_delay = "0s"
+    startup_delay = "100ms"
+
+  [plugins."io.containerd.grpc.v1.cri"]
+    disable_apparmor = false
+    disable_cgroup = false
+    disable_hugetlb_controller = false
+    disable_proc_mount = false
+    disable_tcp_service = true
+    enable_selinux = false
+    enable_tls_streaming = false
+    ignore_image_defined_volumes = false
+    max_concurrent_downloads = 3
+    max_container_log_line_size = 16384
+    netns_mounts_under_state_dir = false
+    restrict_oom_score_adj = false
+    sandbox_image = "k8s.gcr.io/pause:3.5"
+    selinux_category_range = 0
+    stats_collect_period = 10
+    stream_idle_timeout = "4h0m0s"
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    systemd_cgroup = false
+    tolerate_missing_hugetlb_controller = false
+    unset_seccomp_profile = ""
+
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "C:\\Program Files\\containerd\\cni\\bin"
+      conf_dir = "C:\\Program Files\\containerd\\cni\\conf"
+      conf_template = ""
+      max_conf_num = 1
+
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      default_runtime_name = "runhcs-wcow-process"
+      disable_snapshot_annotations = false
+      discard_unpacked_layers = false
+      no_pivot = false
+      snapshotter = "windows"
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+        base_runtime_spec = ""
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        runtime_engine = ""
+        runtime_root = ""
+        runtime_type = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-process]
+          base_runtime_spec = ""
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          runtime_engine = ""
+          runtime_root = ""
+          runtime_type = "io.containerd.runhcs.v1"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-process.options]
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+        base_runtime_spec = ""
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        runtime_engine = ""
+        runtime_root = ""
+        runtime_type = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime.options]
+
+    [plugins."io.containerd.grpc.v1.cri".image_decryption]
+      key_model = "node"
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = ""
+
+      [plugins."io.containerd.grpc.v1.cri".registry.auths]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.headers]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+
+    [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "C:\\ProgramData\\containerd\\root\\opt"
+
+  [plugins."io.containerd.internal.v1.restart"]
+    interval = "10s"
+
+  [plugins."io.containerd.metadata.v1.bolt"]
+    content_sharing_policy = "shared"
+
+  [plugins."io.containerd.runtime.v2.task"]
+    platforms = ["windows/amd64", "linux/amd64"]
+
+  [plugins."io.containerd.service.v1.diff-service"]
+    default = ["windows", "windows-lcow"]
+
+[proxy_plugins]
+
+[stream_processors]
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
+    args = ["--decryption-keys-path", "C:\\Program Files\\containerd\\ocicrypt\\keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=C:\\Program Files\\containerd\\ocicrypt\\ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar"
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
+    args = ["--decryption-keys-path", "C:\\Program Files\\containerd\\ocicrypt\\keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=C:\\Program Files\\containerd\\ocicrypt\\ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+[timeouts]
+  "io.containerd.timeout.shim.cleanup" = "5s"
+  "io.containerd.timeout.shim.load" = "5s"
+  "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.task.state" = "2s"
+
+[ttrpc]
+  address = ""
+  gid = 0
+  uid = 0

--- a/pkg/internal/containerd_conf.toml
+++ b/pkg/internal/containerd_conf.toml
@@ -64,8 +64,8 @@ version = 2
     unset_seccomp_profile = ""
 
     [plugins."io.containerd.grpc.v1.cri".cni]
-      bin_dir = "C:\\Program Files\\containerd\\cni\\bin"
-      conf_dir = "C:\\Program Files\\containerd\\cni\\conf"
+      bin_dir = "C:\\k\\cni"
+      conf_dir = "C:\\k\\cni\\config"
       conf_template = ""
       max_conf_num = 1
 

--- a/test/e2e/bootstrapper_test.go
+++ b/test/e2e/bootstrapper_test.go
@@ -64,7 +64,8 @@ func TestBootstrapper(t *testing.T) {
 	t.Run("Uninstall kubelet without kubelet service present", testUninstallWithoutKubeletSvc)
 
 	// Run the bootstrapper, which will start the kubelet service
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper(installDir, ignitionFilePath, kubeletPath, "", "", "", "", platformType)
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper(installDir, ignitionFilePath, kubeletPath, "", "",
+		"", "", platformType, true)
 	require.NoErrorf(t, err, "Could not create WinNodeBootstrapper: %s", err)
 	err = wmcb.InitializeKubelet()
 	assert.NoErrorf(t, err, "Could not run bootstrapper: %s", err)

--- a/test/e2e/configure_cni_test.go
+++ b/test/e2e/configure_cni_test.go
@@ -42,7 +42,8 @@ func testConfigureCNIWithoutKubeletSvc(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Instantiate the bootstrapper
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper(tempDir, "", "", "", "", tempDir, cniConfig.Name(), platformType)
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper(tempDir, "", "", "", "",
+		tempDir, cniConfig.Name(), platformType, true)
 	require.NoError(t, err, "could not instantiate wmcb")
 
 	err = wmcb.Configure()
@@ -53,7 +54,8 @@ func testConfigureCNIWithoutKubeletSvc(t *testing.T) {
 // testConfigureCNI tests if ConfigureCNI() runs successfully by checking if the kubelet service comes up after
 // configuring CNI
 func testConfigureCNI(t *testing.T) {
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper(installDir, "", "", "", "", cniDir, cniConfig, platformType)
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper(installDir, "", "", "", "",
+		cniDir, cniConfig, platformType, true)
 	require.NoError(t, err, "could not create wmcb")
 
 	err = wmcb.Configure()

--- a/test/e2e/configure_cni_test.go
+++ b/test/e2e/configure_cni_test.go
@@ -55,7 +55,7 @@ func testConfigureCNIWithoutKubeletSvc(t *testing.T) {
 // configuring CNI
 func testConfigureCNI(t *testing.T) {
 	wmcb, err := bootstrapper.NewWinNodeBootstrapper(installDir, "", "", "", "",
-		cniDir, cniConfig, platformType, true)
+		cniDir, cniConfig, platformType, dockerRuntime)
 	require.NoError(t, err, "could not create wmcb")
 
 	err = wmcb.Configure()
@@ -73,9 +73,12 @@ func testConfigureCNI(t *testing.T) {
 	time.Sleep(10 * time.Second)
 
 	assert.True(t, isKubeletRunning(t, kubeletLogPath))
-	isConfiguredCorrectly, err := isCNIConfigured(t, kubeletLogPath)
-	require.NoError(t, err, "Error reading kubelet log")
-	assert.True(t, isConfiguredCorrectly, "CNI was not configured correctly")
+	// if the runtime is containerd, the kubelet log test is not applicable as the log was appended by dockershim.
+	if dockerRuntime {
+		isConfiguredCorrectly, err := isCNIConfigured(t, kubeletLogPath)
+		require.NoError(t, err, "Error reading kubelet log")
+		assert.True(t, isConfiguredCorrectly, "CNI was not configured correctly")
+	}
 
 	// Kubelet arguments with paths that are set by configure-cni
 	// Does not include arguments with paths that do not depend on underlying OS

--- a/test/e2e/uninstall_kubelet_test.go
+++ b/test/e2e/uninstall_kubelet_test.go
@@ -11,7 +11,8 @@ import (
 
 // TestKubeletUninstall tests if WMCB returns an error if the kubelet is uninstalled
 func TestKubeletUninstall(t *testing.T) {
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "", "", "", "")
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "",
+		"", "", "", true)
 	require.NoError(t, err, "could not create wmcb")
 
 	err = wmcb.UninstallKubelet()
@@ -29,7 +30,8 @@ func testUninstallWithoutKubeletSvc(t *testing.T) {
 		t.Skip("Skipping as kubelet service already exists")
 	}
 
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "", "", "", "")
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "",
+		"", "", "", true)
 	require.NoError(t, err, "could not create wmcb")
 
 	err = wmcb.UninstallKubelet()


### PR DESCRIPTION
This PR adds the --dockerRuntime flag option to allow passing containerd specific kubelet config params
while starting kubelet service. This will also allow kubelet to set a dependency on the underlying container runtime present.
It also starts using the DOCKER_RUNTIME env var passed from the release repo in the CCM job config to set the flag value for --dockerRuntime and install containerd Windows service to test the kubelet config changes.
