### PR TITLE
Revert addition of dockerRuntime flag

### DIFF
--- a/cmd/bootstrapper/configure_cni.go
+++ b/cmd/bootstrapper/configure_cni.go
@@ -55,7 +55,7 @@ func runConfigureCNICmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	wmcb, err := bootstrapper.NewWinNodeBootstrapper(configureCNIOpts.installDir, "", "", "", "", configureCNIOpts.dir,
-		configureCNIOpts.config, "", true)
+		configureCNIOpts.config, "")
 	if err != nil {
 		log.Error(err, "could not create bootstrapper")
 		os.Exit(1)

--- a/cmd/bootstrapper/initialize_kubelet.go
+++ b/cmd/bootstrapper/initialize_kubelet.go
@@ -41,9 +41,6 @@ var (
 		clusterDNS string
 		// platformType contains type of the platform where the cluster is deployed
 		platformType string
-		// dockerRuntime set to true indicates the container runtime to be used is docker.
-		// If set to false containerd will be the container runtime.
-		dockerRuntime bool
 	}
 )
 
@@ -63,8 +60,6 @@ func init() {
 			"If unset, kubelet will determine the DNS server to use.")
 	initializeKubeletCmd.PersistentFlags().StringVar(&initializeKubeletOpts.platformType, "platform-type", "",
 		"Type of the platform where the cluster is deployed. Example: AWS, Azure, GCP")
-	initializeKubeletCmd.PersistentFlags().BoolVar(&initializeKubeletOpts.dockerRuntime, "dockerRuntime", true,
-		"Use docker as container runtime. If unset, defaults to true. If false, containerd will be used as the container runtime.")
 }
 
 // runInitializeKubeletCmd starts the Windows Machine Config Bootstrapper
@@ -75,7 +70,7 @@ func runInitializeKubeletCmd(cmd *cobra.Command, args []string) {
 	wmcb, err := bootstrapper.NewWinNodeBootstrapper(initializeKubeletOpts.installDir,
 		initializeKubeletOpts.ignitionFile, initializeKubeletOpts.kubeletPath,
 		initializeKubeletOpts.nodeIP, initializeKubeletOpts.clusterDNS, "", "",
-		initializeKubeletOpts.platformType, initializeKubeletOpts.dockerRuntime)
+		initializeKubeletOpts.platformType)
 	if err != nil {
 		log.Error(err, "could not create bootstrapper")
 		os.Exit(1)

--- a/cmd/bootstrapper/uninstall_kubelet.go
+++ b/cmd/bootstrapper/uninstall_kubelet.go
@@ -27,7 +27,7 @@ func init() {
 func runUninstallKubeletCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "",
-		"", "", "", true)
+		"", "", "")
 	if err != nil {
 		log.Error(err, "could not create bootstrapper")
 		os.Exit(1)

--- a/hack/run-wmcb-ci-e2e-test.sh
+++ b/hack/run-wmcb-ci-e2e-test.sh
@@ -57,11 +57,6 @@ fi
 sed -i "s~ARTIFACT_DIR_VALUE~${ARTIFACT_DIR}~g" internal/test/wmcb/deploy/job.yaml
 sed -i "s~REPLACE_IMAGE~${WMCB_IMAGE}~g" internal/test/wmcb/deploy/job.yaml
 
-# If DOCKER_RUNTIME is set, set that value for flag -dockerRuntime in job.yaml.
-# If it is unset, default value taken will be true.
-DOCKER_RUNTIME=${DOCKER_RUNTIME:-true}
-sed -i "s~DOCKER_RUNTIME~${DOCKER_RUNTIME}~g" internal/test/wmcb/deploy/job.yaml
-
 # deploy the test pod on test cluster
 if ! $OC apply -f internal/test/wmcb/deploy/job.yaml -n default; then
     echo "job already deployed"

--- a/internal/test/wmcb/deploy/job.yaml
+++ b/internal/test/wmcb/deploy/job.yaml
@@ -26,7 +26,6 @@ spec:
           args:
             - -test.run=TestWMCB
             - -test.v
-            - -dockerRuntime=DOCKER_RUNTIME
           volumeMounts:
           - name: cloud-private-key
             mountPath: "/etc/private-key/"

--- a/internal/test/wmcb/main_test.go
+++ b/internal/test/wmcb/main_test.go
@@ -13,16 +13,13 @@ var (
 	framework = wmcbFramework{}
 	// TODO: expose this to the end user as a command line flag
 	// vmCount is the number of VMs the test suite requires
-	vmCount       = 1
-	dockerRuntime bool
+	vmCount = 1
 )
 
 func TestMain(m *testing.M) {
 	var skipVMSetup bool
 
 	flag.BoolVar(&skipVMSetup, "skipVMSetup", false, "Option to disable setup in the VMs")
-	flag.BoolVar(&dockerRuntime, "dockerRuntime", true, "Container runtime to be used is docker")
-
 	flag.Parse()
 
 	err := framework.Setup(vmCount, skipVMSetup)

--- a/pkg/bootstrapper/bootstrapper_test.go
+++ b/pkg/bootstrapper/bootstrapper_test.go
@@ -273,7 +273,10 @@ func TestKubeletArgs(t *testing.T) {
 		"--node-labels=node.openshift.io/os_id=Windows",
 		"--image-pull-progress-deadline=30m",
 		"--cloud-provider=aws",
-		"--v=3"}
+		"--v=3",
+		"--container-runtime=remote",
+		"--container-runtime-endpoint=npipe://./pipe/containerd-containerd",
+	}
 	testIO := []struct {
 		name                   string
 		additionalExpectedArgs []string
@@ -287,7 +290,6 @@ func TestKubeletArgs(t *testing.T) {
 				kubeconfigPath:  filepath.Join("/fakepath/kubeconfig"),
 				kubeletConfPath: filepath.Join("/fakepath/kubelet.conf"),
 				logDir:          "/fakepath/",
-				dockerRuntime:   true,
 			},
 		},
 		{
@@ -299,19 +301,6 @@ func TestKubeletArgs(t *testing.T) {
 				kubeletConfPath: filepath.Join("/fakepath/kubelet.conf"),
 				logDir:          "/fakepath/",
 				nodeIP:          "192.168.1.1",
-				dockerRuntime:   true,
-			},
-		},
-		{
-			name: "With docker runtime set to false",
-			additionalExpectedArgs: []string{"--container-runtime=remote",
-				"--container-runtime-endpoint=npipe://./pipe/containerd-containerd"},
-			wnb: winNodeBootstrapper{
-				installDir:      dir,
-				kubeconfigPath:  filepath.Join("/fakepath/kubeconfig"),
-				kubeletConfPath: filepath.Join("/fakepath/kubelet.conf"),
-				logDir:          "/fakepath/",
-				dockerRuntime:   false,
 			},
 		},
 	}
@@ -442,11 +431,11 @@ func TestCloudConfInvalidNames(t *testing.T) {
 // TestNewWinNodeBootstrapperWithInvalidCNIInputs tests if NewWinNodeBootstrapper returns the expected error on passing
 // invalid CNI inputs
 func TestNewWinNodeBootstrapperWithInvalidCNIInputs(t *testing.T) {
-	_, err := NewWinNodeBootstrapper("", "", "", "", "", "C:\\something", "", "", true)
+	_, err := NewWinNodeBootstrapper("", "", "", "", "", "C:\\something", "", "")
 	require.Error(t, err, "no error thrown when cniDir is not empty and cniConfig is empty")
 	assert.Contains(t, err.Error(), "both cniDir and cniConfig need to be populated", "incorrect error thrown")
 
-	_, err = NewWinNodeBootstrapper("", "", "", "", "", "", "C:\\something", "", true)
+	_, err = NewWinNodeBootstrapper("", "", "", "", "", "", "C:\\something", "")
 	require.Error(t, err, "no error thrown when cniDir is empty and cniConfig not empty")
 	assert.Contains(t, err.Error(), "both cniDir and cniConfig need to be populated", "incorrect error thrown")
 }
@@ -454,7 +443,7 @@ func TestNewWinNodeBootstrapperWithInvalidCNIInputs(t *testing.T) {
 // TestWinNodeBootstrapperConfigureWithInvalidInputs tests if Configure returns the expected error when CNI inputs
 // are not present
 func TestWinNodeBootstrapperConfigureWithInvalidInputs(t *testing.T) {
-	wnb, err := NewWinNodeBootstrapper("", "", "", "", "", "", "", "", true)
+	wnb, err := NewWinNodeBootstrapper("", "", "", "", "", "", "", "")
 	require.NoError(t, err, "error instantiating bootstrapper")
 	err = wnb.Configure()
 	require.Error(t, err, "no error thrown when Configure is called with no CNI inputs")

--- a/test/e2e/bootstrapper_test.go
+++ b/test/e2e/bootstrapper_test.go
@@ -21,7 +21,6 @@ var ignitionFilePath string
 var kubeletPath string
 var installDir string
 var platformType string
-var dockerRuntime bool
 
 const (
 	kubeletLogPath = "C:\\var\\log\\kubelet\\kubelet.log"
@@ -39,7 +38,6 @@ func init() {
 	pflag.StringVar(&kubeletPath, "kubelet-path", "C:\\Windows\\Temp\\kubelet.exe", "kubelet location")
 	pflag.StringVar(&installDir, "install-dir", "C:\\k", "Installation directory")
 	pflag.StringVar(&platformType, "platform-type", "", "platform type")
-	pflag.BoolVar(&dockerRuntime, "dockerRuntime", true, "Container runtime to be used")
 }
 
 // TestBootstrapper tests that the bootstrapper was able to start the required services
@@ -67,7 +65,7 @@ func TestBootstrapper(t *testing.T) {
 
 	// Run the bootstrapper, which will start the kubelet service
 	wmcb, err := bootstrapper.NewWinNodeBootstrapper(installDir, ignitionFilePath, kubeletPath, "", "",
-		"", "", platformType, dockerRuntime)
+		"", "", platformType)
 	require.NoErrorf(t, err, "Could not create WinNodeBootstrapper: %s", err)
 	err = wmcb.InitializeKubelet()
 	assert.NoErrorf(t, err, "Could not run bootstrapper: %s", err)
@@ -103,10 +101,7 @@ func TestBootstrapper(t *testing.T) {
 	// Does not include node-labels and container-image since their paths do not depend on underlying OS
 	checkPathsFor := []string{"--bootstrap-kubeconfig", "--cloud-config", "--config", "--kubeconfig", "--log-file",
 		"--cert-dir"}
-	expectedDependencies := []string{"docker"}
-	if !dockerRuntime {
-		expectedDependencies = []string{"containerd"}
-	}
+	expectedDependencies := []string{"containerd"}
 
 	_, path, actualDependencies, err := getSvcInfo(bootstrapper.KubeletServiceName)
 	require.NoError(t, err, "Could not get kubelet arguments")

--- a/test/e2e/uninstall_kubelet_test.go
+++ b/test/e2e/uninstall_kubelet_test.go
@@ -12,7 +12,7 @@ import (
 // TestKubeletUninstall tests if WMCB returns an error if the kubelet is uninstalled
 func TestKubeletUninstall(t *testing.T) {
 	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "",
-		"", "", "", true)
+		"", "", "")
 	require.NoError(t, err, "could not create wmcb")
 
 	err = wmcb.UninstallKubelet()
@@ -31,7 +31,7 @@ func testUninstallWithoutKubeletSvc(t *testing.T) {
 	}
 
 	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "",
-		"", "", "", true)
+		"", "", "")
 	require.NoError(t, err, "could not create wmcb")
 
 	err = wmcb.UninstallKubelet()


### PR DESCRIPTION
This PR reverts the addition and usage of dockerRuntime flag option. It was added with the anticipation of using docker and containerd runtimes in the same release.
However containerd feature is now expected to be fully supported in 6.0 time-frame while removing support for docker container runtime which makes this flag option no longer useful.