### PR TITLE
Add optional parameter for kubelet verbosity

### DIFF
--- a/cmd/bootstrapper/initialize_kubelet.go
+++ b/cmd/bootstrapper/initialize_kubelet.go
@@ -33,6 +33,8 @@ var (
 		ignitionFile string
 		// The location where the kubelet.exe has been downloaded to
 		kubeletPath string
+		// kubeletVerbosity represents the log level for kubelet
+		kubeletVerbosity string
 		// The directory to install the kubelet and related files
 		installDir string
 		// nodeIP directs the kubelet to use a specific IP for the node object
@@ -50,6 +52,9 @@ func init() {
 		"Ignition file location to bootstrap the Windows node")
 	initializeKubeletCmd.PersistentFlags().StringVar(&initializeKubeletOpts.kubeletPath, "kubelet-path", "",
 		"Kubelet file location to bootstrap the Windows node")
+	initializeKubeletCmd.PersistentFlags().StringVar(&initializeKubeletOpts.kubeletVerbosity, "kubelet-verbosity",
+		"", "Represents the log level for kubelet. If unset, will use the value in the kubelet' systemd unit "+
+			"file, if any, or default to "+bootstrapper.KubeletDefaultVerbosity)
 	initializeKubeletCmd.PersistentFlags().StringVar(&initializeKubeletOpts.installDir, "install-dir", "c:\\k",
 		"Kubelet file location to bootstrap the Windows node. Defaults to C:\\k")
 	initializeKubeletCmd.PersistentFlags().StringVar(&initializeKubeletOpts.nodeIP, "node-ip", "",
@@ -68,7 +73,7 @@ func runInitializeKubeletCmd(cmd *cobra.Command, args []string) {
 	// TODO: add validation for flags
 
 	wmcb, err := bootstrapper.NewWinNodeBootstrapper(initializeKubeletOpts.installDir,
-		initializeKubeletOpts.ignitionFile, initializeKubeletOpts.kubeletPath,
+		initializeKubeletOpts.ignitionFile, initializeKubeletOpts.kubeletPath, initializeKubeletOpts.kubeletVerbosity,
 		initializeKubeletOpts.nodeIP, initializeKubeletOpts.clusterDNS,
 		initializeKubeletOpts.platformType)
 	if err != nil {

--- a/cmd/bootstrapper/uninstall_kubelet.go
+++ b/cmd/bootstrapper/uninstall_kubelet.go
@@ -26,7 +26,7 @@ func init() {
 // runUninstallKubeletCmd uninstalls kubelet service from the Windows node
 func runUninstallKubeletCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "",
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "", "",
 		"")
 	if err != nil {
 		log.Error(err, "could not create bootstrapper")

--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -40,6 +40,8 @@ const (
 	// KubeletServiceName is the name will we run the kubelet Windows service under. It is required to be named "kubelet":
 	// https://github.com/kubernetes/kubernetes/blob/v1.16.0/cmd/kubelet/app/init_windows.go#L26
 	KubeletServiceName = "kubelet"
+	// KubeletDefaultVerbosity is the recommended default log level for kubelet. See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
+	KubeletDefaultVerbosity = "3"
 	// kubeletDependentSvc is the name of the service dependent on kubelet Windows service
 	kubeletDependentSvc = "hybrid-overlay-node"
 	// kubeletSystemdName is the name of the systemd service that the kubelet runs under,
@@ -96,6 +98,8 @@ type winNodeBootstrapper struct {
 	kubeconfigPath string
 	// kubeletConfPath is the file path of the kubelet configuration
 	kubeletConfPath string
+	// kubeletVerbosity represents the log level for kubelet
+	kubeletVerbosity string
 	// ignitionFilePath is the path to the ignition file which is used to set up worker nodes
 	// https://github.com/coreos/ignition/blob/spec2x/doc/getting-started.md
 	ignitionFilePath string
@@ -121,11 +125,11 @@ type winNodeBootstrapper struct {
 	platformType string
 }
 
-// NewWinNodeBootstrapper takes the dir to install the kubelet to, and paths to the ignition and kubelet files, an
-// optional node IP, an optional clusterDNS, along with the CNI options as inputs, and generates the winNodeBootstrapper
-// object. The CNI options are populated only in the configure-cni command. The inputs to NewWinNodeBootstrapper are
-// ignored while using the uninstall kubelet functionality.
-func NewWinNodeBootstrapper(k8sInstallDir, ignitionFile, kubeletPath, nodeIP, clusterDNS,
+// NewWinNodeBootstrapper takes the dir to install the kubelet to, the verbosity and paths to the ignition and kubelet
+// files, an optional node IP, an optional clusterDNS, along with the CNI options as inputs, and generates the
+// winNodeBootstrapper object. The CNI options are populated only in the configure-cni command. The inputs to
+// NewWinNodeBootstrapper are ignored while using the uninstall kubelet functionality.
+func NewWinNodeBootstrapper(k8sInstallDir, ignitionFile, kubeletPath, kubeletVerbosity, nodeIP, clusterDNS,
 	platformType string) (*winNodeBootstrapper, error) {
 	// If nodeIP is set, ensure that it is a valid IP
 	if nodeIP != "" {
@@ -148,6 +152,7 @@ func NewWinNodeBootstrapper(k8sInstallDir, ignitionFile, kubeletPath, nodeIP, cl
 	bootstrapper := winNodeBootstrapper{
 		kubeconfigPath:     filepath.Join(k8sInstallDir, "kubeconfig"),
 		kubeletConfPath:    filepath.Join(k8sInstallDir, "kubelet.conf"),
+		kubeletVerbosity:   kubeletVerbosity,
 		ignitionFilePath:   ignitionFile,
 		installDir:         k8sInstallDir,
 		logDir:             "C:\\var\\log\\kubelet",
@@ -482,12 +487,20 @@ func (wmcb *winNodeBootstrapper) generateInitialKubeletArgs(args map[string]stri
 	if cloudProvider, ok := args["cloud-provider"]; ok {
 		kubeletArgs = append(kubeletArgs, "--cloud-provider="+cloudProvider)
 	}
-	if v, ok := args["v"]; ok && v != "" {
-		kubeletArgs = append(kubeletArgs, "--v="+v)
+	// set default verbosity for kubelet
+	kubeletVerbosity := KubeletDefaultVerbosity
+	// set the verbosity value from the program argument if any, this takes precedence
+	if wmcb.kubeletVerbosity != "" {
+		kubeletVerbosity = wmcb.kubeletVerbosity
 	} else {
-		// In case the verbosity argument is missing, use a default value
-		kubeletArgs = append(kubeletArgs, "--v="+"3")
+		// otherwise look for verbosity value in kubelet systemd unit file configuration
+		if v, ok := args["v"]; ok && v != "" {
+			// and update, if found
+			kubeletVerbosity = v
+		}
 	}
+	kubeletArgs = append(kubeletArgs, "--v="+kubeletVerbosity)
+
 	if cloudConfigValue, ok := args[cloudConfigOption]; ok {
 		kubeletArgs = append(kubeletArgs, "--"+cloudConfigOption+"="+cloudConfigValue)
 	}

--- a/pkg/bootstrapper/bootstrapper_test.go
+++ b/pkg/bootstrapper/bootstrapper_test.go
@@ -259,6 +259,63 @@ func TestKubeletArgs(t *testing.T) {
 
 }
 
+// TestKubeletVerbosityArgs tests the kubelet verbosity argument populates correctly
+func TestKubeletVerbosityArgs(t *testing.T) {
+	ignitionContentsWithoutKubeletVerbosity := `{"ignition":{"version":"3.1.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["ssh-rsa dummy"]}]},"systemd":{"units":[{"contents":"[Unit]\nDescription=Kubernetes Kubelet\nWants=rpc-statd.service crio.service\nAfter=crio.service\n\n[Service]\nType=notify\nExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests\nExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state\nEnvironmentFile=/etc/os-release\nEnvironmentFile=-/etc/kubernetes/kubelet-workaround\nEnvironmentFile=-/etc/kubernetes/kubelet-env\n\nExecStart=/usr/bin/hyperkube \\\n    kubelet \\\n      --config=/etc/kubernetes/kubelet.conf \\\n      --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \\\n      --kubeconfig=/var/lib/kubelet/kubeconfig \\\n      --container-runtime=remote \\\n      --container-runtime-endpoint=/var/run/crio/crio.sock \\\n      --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \\\n      --minimum-container-ttl-duration=6m0s \\\n      --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \\\n      --cloud-provider=aws \\\n      Restart=always\nRestartSec=10\n\n[Install]\nWantedBy=multi-user.target\n","enabled":true,"name":"kubelet.service"}]}}`
+	ignitionContentsWithKubeletVerbosity := `{"ignition":{"version":"3.1.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["ssh-rsa dummy"]}]},"systemd":{"units":[{"contents":"[Unit]\nDescription=Kubernetes Kubelet\nWants=rpc-statd.service crio.service\nAfter=crio.service\n\n[Service]\nType=notify\nExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests\nExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state\nEnvironmentFile=/etc/os-release\nEnvironmentFile=-/etc/kubernetes/kubelet-workaround\nEnvironmentFile=-/etc/kubernetes/kubelet-env\n\nExecStart=/usr/bin/hyperkube \\\n    kubelet \\\n      --config=/etc/kubernetes/kubelet.conf \\\n      --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \\\n      --kubeconfig=/var/lib/kubelet/kubeconfig \\\n      --container-runtime=remote \\\n      --container-runtime-endpoint=/var/run/crio/crio.sock \\\n      --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \\\n      --minimum-container-ttl-duration=6m0s \\\n      --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \\\n      --cloud-provider=aws \\\n      --v=1\n\nRestart=always\nRestartSec=10\n\n[Install]\nWantedBy=multi-user.target\n","enabled":true,"name":"kubelet.service"}]}}`
+
+	baseExpectedArgs := []string{"--config=",
+		"--bootstrap-kubeconfig=bootstrap-kubeconfig",
+		"--kubeconfig=",
+		"--cert-dir=c:\\var\\lib\\kubelet\\pki\\",
+		"--windows-service",
+		"--logtostderr=false",
+		"--log-file=kubelet.log",
+		"--register-with-taints=os=Windows:NoSchedule",
+		"--node-labels=node.openshift.io/os_id=Windows",
+		"--container-runtime=remote",
+		"--container-runtime-endpoint=npipe://./pipe/containerd-containerd",
+		"--resolv-conf=",
+		"--cloud-provider=aws",
+	}
+
+	testIO := []struct {
+		name                   string
+		ignitionContents       string
+		additionalExpectedArgs []string
+		wnb                    winNodeBootstrapper
+	}{
+		{
+			name:                   "verbosity present in ignition content should use it",
+			ignitionContents:       ignitionContentsWithKubeletVerbosity,
+			additionalExpectedArgs: []string{"--v=1"},
+			wnb:                    winNodeBootstrapper{},
+		},
+		{
+			name:                   "verbosity present program argument should use it",
+			ignitionContents:       ignitionContentsWithKubeletVerbosity,
+			additionalExpectedArgs: []string{"--v=2"},
+			wnb: winNodeBootstrapper{
+				kubeletVerbosity: "2",
+			},
+		},
+		{
+			name:                   "no verbosity should load default",
+			ignitionContents:       ignitionContentsWithoutKubeletVerbosity,
+			additionalExpectedArgs: []string{"--v=3"},
+			wnb:                    winNodeBootstrapper{},
+		},
+	}
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			expectedArgs := append(baseExpectedArgs, test.additionalExpectedArgs...)
+			err := test.wnb.parseIgnitionFileContents([]byte(test.ignitionContents), map[string]fileTranslation{})
+			require.NoError(t, err, "error parsing ignition file contents")
+			assert.ElementsMatch(t, expectedArgs, test.wnb.kubeletArgs, "unexpected kubelet args")
+		})
+	}
+}
+
 func TestCloudConfExtraction(t *testing.T) {
 	// ignitionContents is the actual worker ignition contents from an azure cluster with dummy credentials and
 	// resources

--- a/test/e2e/bootstrapper_test.go
+++ b/test/e2e/bootstrapper_test.go
@@ -59,7 +59,7 @@ func TestBootstrapper(t *testing.T) {
 	t.Run("Uninstall kubelet without kubelet service present", testUninstallWithoutKubeletSvc)
 
 	// Run the bootstrapper, which will start the kubelet service
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper(installDir, ignitionFilePath, kubeletPath, "", "",
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper(installDir, ignitionFilePath, kubeletPath, "", "", "",
 		platformType)
 	require.NoErrorf(t, err, "Could not create WinNodeBootstrapper: %s", err)
 	err = wmcb.InitializeKubelet()

--- a/test/e2e/uninstall_kubelet_test.go
+++ b/test/e2e/uninstall_kubelet_test.go
@@ -11,7 +11,7 @@ import (
 
 // TestKubeletUninstall tests if WMCB returns an error if the kubelet is uninstalled
 func TestKubeletUninstall(t *testing.T) {
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "",
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "", "",
 		"")
 	require.NoError(t, err, "could not create wmcb")
 
@@ -30,7 +30,7 @@ func testUninstallWithoutKubeletSvc(t *testing.T) {
 		t.Skip("Skipping as kubelet service already exists")
 	}
 
-	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "",
+	wmcb, err := bootstrapper.NewWinNodeBootstrapper("", "", "", "", "",
 		"", "")
 	require.NoError(t, err, "could not create wmcb")
 


### PR DESCRIPTION
This change introduces an optional program argument to
set the kubelet log level. If unset, wmcb.exe will use
the verbosity value in the kubelet systemd unit provided
by the ignition file (if any) or default to 3. The novel
program argument takes precedence over the later two.