### PR TITLE
Bump Go version to 1.18

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: golang-1.17
+  tag: golang-1.18

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.17 as build
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as build
 LABEL stage=build
 
 # dos2unix is needed to build CNI plugins
@@ -42,7 +42,7 @@ RUN make build-wmcb-e2e-test
 WORKDIR /build/internal/test/wmcb/
 RUN CGO_ENABLED=0 GO111MODULE=on go test -c -run=TestWMCB -timeout=30m . -o test-wmcb
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.17 as testing
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as testing
 LABEL stage=testing
 
 WORKDIR /payload/cni

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/windows-machine-config-bootstrapper
 
-go 1.17
+go 1.18
 
 // Replace is used to pin a specific version of a package or to point to sub-go.mod directories.
 // Use 'replace' to point to the sub-go.mod directory for building a binary in the root directory and always build by

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -5,7 +5,7 @@ WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.17') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.18') ]]; then
   echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
   exit 1
 fi


### PR DESCRIPTION
This change bumps the Go version to 1.18.

Follow-up to https://github.com/openshift/windows-machine-config-operator/commit/c322f973a8ea7bd95a85e9f2d10d2b5687aa7eb9

Ran:
`go mod edit -go=1.18 && go mod tidy && go mod vendor`