### PR TITLE
WINC-879: [hack] Add the pod security labels in default namespace

### DIFF
--- a/hack/run-wmcb-ci-e2e-test.sh
+++ b/hack/run-wmcb-ci-e2e-test.sh
@@ -57,6 +57,19 @@ fi
 sed -i "s~ARTIFACT_DIR_VALUE~${ARTIFACT_DIR}~g" internal/test/wmcb/deploy/job.yaml
 sed -i "s~REPLACE_IMAGE~${WMCB_IMAGE}~g" internal/test/wmcb/deploy/job.yaml
 
+# declare required labels
+declare -a NS_LABELS=(
+  # turn on the automatic label synchronization required for PodSecurity admission
+  "security.openshift.io/scc.podSecurityLabelSync=true"
+  # set pods security profile to privileged. See https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-levels
+  "pod-security.kubernetes.io/enforce=privileged"
+)
+
+# apply required labels
+if ! $OC label ns default "${NS_LABELS[@]}" --overwrite; then
+  error-exit "error setting labels ${NS_LABELS[@]} in namespace default"
+fi
+
 # deploy the test pod on test cluster
 if ! $OC apply -f internal/test/wmcb/deploy/job.yaml -n default; then
     echo "job already deployed"


### PR DESCRIPTION
This change turns on the automatic Pod Security label synchronization by adding the recommended labels in the default namespace. Follow up to openshift/windows-machine-config-operator@fed9c3cfb0f259316cb7a62eb288b4ed9e2a293f